### PR TITLE
Generic search method

### DIFF
--- a/legacy-schema.yaml
+++ b/legacy-schema.yaml
@@ -169,17 +169,6 @@ definitions:
   data:
     title: Search result
     type: object
-    required:
-      - creator
-      - shared_users
-      - timestamp
-      - creation_date
-      - is_public
-      - access_group
-      - obj_id
-      - version
-      - copied
-      - tags
     properties:
       creator: {type: string}
       shared_users:
@@ -291,7 +280,13 @@ definitions:
         type: integer
       - title: Object name
         type: string
-      - title: Saved at
+      - title: Type
+        type: string
+      - title: Saved Date
+        type: string
+      - title: Version
+        type: integer
+      - title: Author
         type: string
       - title: Workspace Id
         type: integer

--- a/rpc-schema.yaml
+++ b/rpc-schema.yaml
@@ -71,6 +71,7 @@ definitions:
             examples:
               - [[field1, asc], [field2, desc]]
             type: array
+            default: ["_score", "desc"]
             items:
               type: array
               minLength: 2

--- a/rpc-schema.yaml
+++ b/rpc-schema.yaml
@@ -82,12 +82,7 @@ definitions:
                   title: Sort direction
                   enum: ["asc", "desc"]
           filters:
-            title: Filters
-            description: |
-              Exact term and range matches on specific fields, with boolean
-              conjunction/disjunction
-            type:
-              "$ref": "#/definitions/filter_clause"
+            "$ref": "#/definitions/filter_clause"
           paging:
             type: object
             additionalProperties: false

--- a/rpc-schema.yaml
+++ b/rpc-schema.yaml
@@ -1,9 +1,9 @@
 ---
 $schema: http://json-schema.org/draft-07/schema#
 title: Search2 Method Schemas
-# JSON Schema definitions for every RPC method in this service
 definitions:
 
+  # JSON Schema definitions for every RPC method in this service
   methods:
     # Display public configuration details for the services
     show_config:
@@ -26,6 +26,90 @@ definitions:
             count:
               title: Document count
               type: integer
+
+    search_workspace:
+      params:
+        type: object
+        required: []
+        properties:
+          types:
+            title: Types
+            description: |
+              Unversioned workspace type names to search against. Defaults to
+              search against all available types.
+            type: array
+            items: {type: string}
+          include_fields:
+            title: Include Fields
+            description: |
+              What fields to include in the results. Supports wildcards. If
+              empty, null, or absent, then all fields are returned.
+            examples:
+              - ["field1", "field2", "field3"]
+            type: array
+            items: {type: string}
+          search:
+            title: Search Query
+            description: Generic search query string
+            examples:
+              - "foo | bar + baz*"
+            type: object
+            required: [query]
+            properties:
+              query:
+                type: string
+                description: Uses Elasticsearch's Simple Query String syntax
+              fields:
+                type: array
+                items: {type: string}
+                default: ["agg_fields"]
+        sorts:
+          title: Sorts
+          description: Fields to use for sorting results
+          examples:
+            - [[field1, asc], [field2, desc]]
+          type: array
+          items:
+            type: array
+            minLength: 2
+            maxLength: 2
+            items:
+              - {type: string, title: "Field Name"}
+              - type: string
+                title: Sort direction
+                enum: ["asc", "desc"]
+        filters:
+          title: Filters
+          description: |
+            Exact term and range matches on specific fields, with boolean
+            conjunction/disjunction
+          type:
+            "$ref": "#/definitions/filter_clause"
+        paging:
+          type: object
+          default: {length: 10, offset: 0}
+          properties:
+            length:
+              type: integer
+              default: 10
+            offset:
+              type: integer
+              default: 0
+        access:
+          type: object
+          default: {only_public: false, only_private: false}
+          properties:
+            only_public:
+              type: boolean
+              description: Only return public documents. No auth needed.
+            only_private:
+              type: boolean
+              description: Only return private documents and no public. Auth required.
+        track_total_hits:
+          type: boolean
+          title: Track total hits
+          description: Track the true total of hits. Bypasses the 10k count limit.
+    # End of search_workspace
 
     # Generic search of all objects under an index or alias
     search_objects:
@@ -160,3 +244,61 @@ definitions:
                     ".*":
                       type: array
                       items: {type: string}
+  # End of search_objects
+
+  # Non-method definitions
+
+  filter_clause:
+    title: Filter Clause
+    description: Filters applied to one or more fields with boolean operators
+    examples:
+      - {field: "field1", term: "xyz"}
+      - {operator: AND, fields: [{field: field1, term: xyz}, {field: field2, term: abc}]}
+    anyOf:
+      - {"$ref": "#/definitions/filter_bool"}
+      - {"$ref": "#/defintions/filter_field"}
+
+  filter_bool:
+    title: Filter Boolean
+    description: Filter multiple fields joined by a boolean operator
+    type: object
+    examples:
+      - {operator: AND, fields: [{field: field1, term: xyz}, {field: field2, term: abc}]}
+    properties:
+      operator:
+        type: string
+        enum: ["AND", "OR"]
+      fields:
+        type: array
+        items:
+          anyOf:
+            - {"$ref": "#/definitions/filter_bool"}
+            - {"$ref": "$/defintions/filter_field"}
+
+  filter_field:
+    title: Filter Single Field
+    description: A filter on a specific field
+    examples:
+      - {field: "field1", term: "xyzvalue"}
+      - {field: "field1", range: {min: 10, max: 100}}
+    type: object
+    required: [field]
+    properties:
+      field: {type: string}
+      range:
+        type: object
+        properties:
+          max:
+            anyOf: [{type: integer}, {type: number}]
+          min:
+            anyOf: [{type: integer}, {type: number}]
+      term: {"$ref": "#/definitions/scalar_type"}
+      not_term: {"$ref": "#/definitions/scalar_type"}
+
+  scalar_type:
+    anyOf:
+      - type: number
+      - type: integer
+      - type: string
+      - type: boolean
+      - type: "null"

--- a/rpc-schema.yaml
+++ b/rpc-schema.yaml
@@ -31,6 +31,7 @@ definitions:
       params:
         type: object
         required: []
+        additionalProperties: false
         properties:
           types:
             title: Types
@@ -55,6 +56,7 @@ definitions:
               - "foo | bar + baz*"
             type: object
             required: [query]
+            additionalProperties: false
             properties:
               query:
                 type: string
@@ -63,52 +65,73 @@ definitions:
                 type: array
                 items: {type: string}
                 default: ["agg_fields"]
-        sorts:
-          title: Sorts
-          description: Fields to use for sorting results
-          examples:
-            - [[field1, asc], [field2, desc]]
-          type: array
-          items:
+          sorts:
+            title: Sorts
+            description: Fields to use for sorting results
+            examples:
+              - [[field1, asc], [field2, desc]]
             type: array
-            minLength: 2
-            maxLength: 2
             items:
-              - {type: string, title: "Field Name"}
-              - type: string
-                title: Sort direction
-                enum: ["asc", "desc"]
-        filters:
-          title: Filters
-          description: |
-            Exact term and range matches on specific fields, with boolean
-            conjunction/disjunction
-          type:
-            "$ref": "#/definitions/filter_clause"
-        paging:
-          type: object
-          default: {length: 10, offset: 0}
-          properties:
-            length:
-              type: integer
-              default: 10
-            offset:
-              type: integer
-              default: 0
-        access:
-          type: object
-          default: {only_public: false, only_private: false}
-          properties:
-            only_public:
-              type: boolean
-              description: Only return public documents. No auth needed.
-            only_private:
-              type: boolean
-              description: Only return private documents and no public. Auth required.
-        track_total_hits:
-          type: boolean
-          title: Track total hits
-          description: Track the true total of hits. Bypasses the 10k count limit.
+              type: array
+              minLength: 2
+              maxLength: 2
+              items:
+                - {type: string, title: "Field Name"}
+                - type: string
+                  title: Sort direction
+                  enum: ["asc", "desc"]
+          filters:
+            title: Filters
+            description: |
+              Exact term and range matches on specific fields, with boolean
+              conjunction/disjunction
+            type:
+              "$ref": "#/definitions/filter_clause"
+          paging:
+            type: object
+            additionalProperties: false
+            default: {length: 10, offset: 0}
+            properties:
+              length:
+                type: integer
+                default: 10
+              offset:
+                type: integer
+                default: 0
+          access:
+            type: object
+            additionalProperties: false
+            default: {only_public: false, only_private: false}
+            properties:
+              only_public:
+                type: boolean
+                description: Only return public documents. No auth needed.
+              only_private:
+                type: boolean
+                description: Only return private documents and no public. Auth required.
+          track_total_hits:
+            type: boolean
+            title: Track total hits
+            description: Track the true total of hits. Bypasses the 10k count limit.
+      # End of search_workspace.params
+      result:
+        type: object
+        required: [count, hits, search_time]
+        additionalProperties: false
+        properties:
+          count:
+            description: Total count of results
+            type: integer
+            minimum: 0
+          search_time:
+            description: |
+              Time in milliseconds that the request took for processing on
+              Elasticsearch
+            type: integer
+            minimum: 0
+          hits:
+            type: array
+            items: {type: object}
     # End of search_workspace
 
     # Generic search of all objects under an index or alias
@@ -256,14 +279,16 @@ definitions:
       - {operator: AND, fields: [{field: field1, term: xyz}, {field: field2, term: abc}]}
     anyOf:
       - {"$ref": "#/definitions/filter_bool"}
-      - {"$ref": "#/defintions/filter_field"}
+      - {"$ref": "#/definitions/filter_field"}
 
   filter_bool:
     title: Filter Boolean
     description: Filter multiple fields joined by a boolean operator
-    type: object
     examples:
       - {operator: AND, fields: [{field: field1, term: xyz}, {field: field2, term: abc}]}
+    type: object
+    additionalProperties: false
+    required: [fields, operator]
     properties:
       operator:
         type: string
@@ -282,11 +307,13 @@ definitions:
       - {field: "field1", term: "xyzvalue"}
       - {field: "field1", range: {min: 10, max: 100}}
     type: object
+    additionalProperties: false
     required: [field]
     properties:
       field: {type: string}
       range:
         type: object
+        additionalProperties: false
         properties:
           max:
             anyOf: [{type: integer}, {type: number}]

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -7,5 +7,6 @@ cleanup () {
 
 cleanup
 trap cleanup EXIT
-
-PYTHONPATH=. pytest -vv -s tests/integration
+path=${1:-"tests/integration"}
+export PYTHONPATH=.
+poetry run pytest -vv -s $path

--- a/src/es_client/query.py
+++ b/src/es_client/query.py
@@ -170,7 +170,6 @@ def _construct_index_name(params):
     # if params.get('exclude_indexes'):
     #     exclusions = params['exclude_indexes']
     #     # FIXME I could not get exclusions (prefixed with minus sign) to work
-    #     # without an asterisk
     #     exclusions_str = ','.join('-' + prefix + '*' + name for name in exclusions)
     #     index_name_str += ',' + exclusions_str
     return index_name_str

--- a/src/es_client/query.py
+++ b/src/es_client/query.py
@@ -22,7 +22,7 @@ def search(params, meta):
     """
     user_query = params.get('query')
     authorized_ws_ids = []
-    if not params.get('public_only') and meta['auth']:
+    if not params.get('only_public') and meta['auth']:
         # Fetch the workspace IDs that the user can read
         # Used for simple access control
         authorized_ws_ids = ws_auth(meta['auth'])
@@ -33,10 +33,10 @@ def search(params, meta):
     if user_query:
         query['bool']['must'] = user_query
     # Our access control query is then inserted under a "filter" depending on options:
-    if params.get('public_only'):
+    if params.get('only_public'):
         # Public workspaces only; most efficient
         query['bool']['filter'] = {'term': {'is_public': True}}
-    elif params.get('private_only'):
+    elif params.get('only_private'):
         # Private workspaces only
         query['bool']['filter'] = [
             {'term': {'is_public': False}},

--- a/src/search2_conversion/__init__.py
+++ b/src/search2_conversion/__init__.py
@@ -1,0 +1,5 @@
+import src.search2_conversion.convert_params as convert_params
+import src.search2_conversion.convert_result as convert_result
+
+__all__ = ['convert_params', 'convert_result']
+

--- a/src/search2_conversion/__init__.py
+++ b/src/search2_conversion/__init__.py
@@ -2,4 +2,3 @@ import src.search2_conversion.convert_params as convert_params
 import src.search2_conversion.convert_result as convert_result
 
 __all__ = ['convert_params', 'convert_result']
-

--- a/src/search2_conversion/convert_params.py
+++ b/src/search2_conversion/convert_params.py
@@ -1,3 +1,4 @@
+from src.utils.config import config
 
 
 def search_workspace(params, meta):
@@ -5,57 +6,76 @@ def search_workspace(params, meta):
     Convert parameters from the client into a format that can be passed into
     the es_client.search function
     """
-    converted = {
-        "query": {
-        }
-    }
+    # Initialize the result of this function
+    converted = {"query": {"bool": {"must": []}}}
     if "access" in params:
         converted["only_public"] = bool(params["access"].get("only_public"))
         converted["only_private"] = bool(params["access"].get("only_private"))
-    converted["track_total_hits"] = bool(params["track_total_hits"])
+    converted["track_total_hits"] = bool(params.get("track_total_hits"))
+    if "types" in params:
+        # Get the index names from KBase type names using global config data
+        indexes = []
+        mapping = config['global']['ws_type_to_indexes']
+        for typ in params['types']:
+            if typ not in mapping:
+                # TODO proper error class with code
+                available = list(mapping.keys())
+                raise RuntimeError(f"Unknown type: {type}. Available types: {available}.")
+            indexes.append(mapping[typ])
+        converted["indexes"] = indexes
     if "sorts" in params:
+        # Convert from our format into Elasticsearch's format
+        # [[field, dir]] -> [{field: {'order': dir}}]
         converted["sort"] = []
         for sort in params.get("sorts"):
             fieldname = sort[0]
             direction = sort[1]
             converted["sort"].append({fieldname: {"order": direction}})
     if "search" in params:
+        # Elasticsearch Simple Query String
         query = params["search"]["query"]
         fields = params["search"]["fields"]
-        converted["query"]["simple_query_string"] = {
-            "fields": fields,
-            "query": query
-        }
+        converted["query"]["bool"]["must"].append({
+            "simple_query_string": {
+                "fields": fields,
+                "query": query,
+                "default_operator": "AND",
+            }
+        })
     if "filters" in params:
-        params["query"]["bool"] = _convert_filters(params['filters'])
-    # TODO convert "filters"
-    return params
+        converted["query"]["bool"]["must"].append(_convert_filters(params['filters']))
+    return converted
 
 
 def _convert_filters(filters):
     if 'operator' in filters:
         # We have a filter clause
         if filters['operator'] == 'AND':
+            # Recursive call for sub-clauses
             return {
                 "must": [
                     _convert_filters(f) for f in filters['fields']
                 ]
             }
         else:
+            # Recursive call for sub-clauses
             return {
                 "should": [
                     _convert_filters(f) for f in filters['fields']
                 ]
             }
     elif "term" in filters:
+        # Base case term match
         return {"term": {filters["field"]: {"value": filters["term"]}}}
     elif "not_term" in filters:
+        # Base case negated term match
         return {
             "must_not": {
-                "term": {filters["field"]: {"value": filters["term"]}}
+                "term": {filters["field"]: {"value": filters["not_term"]}}
             }
         }
     elif "range" in filters:
+        # Base case range filter
         # Convert the range claus into ES syntax
         # Eg, given: {"range": {"min": 10, "max": 11}, "field": "x"}
         #   returns: {"range": {"x": {"gte": 10, "lte": 11}}

--- a/src/search2_conversion/convert_params.py
+++ b/src/search2_conversion/convert_params.py
@@ -1,0 +1,68 @@
+
+
+def search_workspace(params, meta):
+    """
+    Convert parameters from the client into a format that can be passed into
+    the es_client.search function
+    """
+    converted = {
+        "query": {
+        }
+    }
+    if "access" in params:
+        converted["only_public"] = bool(params["access"].get("only_public"))
+        converted["only_private"] = bool(params["access"].get("only_private"))
+    converted["track_total_hits"] = bool(params["track_total_hits"])
+    if "sorts" in params:
+        converted["sort"] = []
+        for sort in params.get("sorts"):
+            fieldname = sort[0]
+            direction = sort[1]
+            converted["sort"].append({fieldname: {"order": direction}})
+    if "search" in params:
+        query = params["search"]["query"]
+        fields = params["search"]["fields"]
+        converted["query"]["simple_query_string"] = {
+            "fields": fields,
+            "query": query
+        }
+    if "filters" in params:
+        params["query"]["bool"] = _convert_filters(params['filters'])
+    # TODO convert "filters"
+    return params
+
+
+def _convert_filters(filters):
+    if 'operator' in filters:
+        # We have a filter clause
+        if filters['operator'] == 'AND':
+            return {
+                "must": [
+                    _convert_filters(f) for f in filters['fields']
+                ]
+            }
+        else:
+            return {
+                "should": [
+                    _convert_filters(f) for f in filters['fields']
+                ]
+            }
+    elif "term" in filters:
+        return {"term": {filters["field"]: {"value": filters["term"]}}}
+    elif "not_term" in filters:
+        return {
+            "must_not": {
+                "term": {filters["field"]: {"value": filters["term"]}}
+            }
+        }
+    elif "range" in filters:
+        # Convert the range claus into ES syntax
+        # Eg, given: {"range": {"min": 10, "max": 11}, "field": "x"}
+        #   returns: {"range": {"x": {"gte": 10, "lte": 11}}
+        field = filters["field"]
+        ret = {"range": {field: {}}}
+        if "max" in filters["range"]:
+            ret["range"][field]["lte"] = filters["range"]["max"]
+        if "min" in filters["range"]:
+            ret["range"][field]["gte"] = filters["range"]["min"]
+        return ret

--- a/src/search2_conversion/convert_params.py
+++ b/src/search2_conversion/convert_params.py
@@ -23,6 +23,9 @@ def search_workspace(params, meta):
                 raise RuntimeError(f"Unknown type: {type}. Available types: {available}.")
             indexes.append(mapping[typ])
         converted["indexes"] = indexes
+    if "types" not in params or len(params["types"]) == 0:
+        indexes = list(config['global']['ws_type_to_indexes'].values())
+        converted["indexes"] = indexes
     if "sorts" in params:
         # Convert from our format into Elasticsearch's format
         # [[field, dir]] -> [{field: {'order': dir}}]

--- a/src/search2_conversion/convert_result.py
+++ b/src/search2_conversion/convert_result.py
@@ -1,0 +1,13 @@
+
+
+def search_workspace(results, params, meta):
+    """
+    Return result data from es_client.query and convert into a format
+    conforming to the schema found in
+    rpc-methods.yaml/definitions/methods/search_workspace/result
+    """
+    return {
+        "search_time": results["search_time"],
+        "count": results["count"],
+        "hits": [hit["doc"] for hit in results["hits"]],
+    }

--- a/src/search2_rpc/service.py
+++ b/src/search2_rpc/service.py
@@ -9,6 +9,7 @@ import time
 from src.es_client import search
 from src.utils.config import config
 from src.utils.logger import logger
+from src.search2_conversion import convert_params, convert_result
 
 service = jsonrpcbase.JSONRPCService(
     info={
@@ -62,6 +63,16 @@ def search_objects(params, meta):
     return result
 
 
+def search_workspace(params, meta):
+    start = time.time()
+    params = convert_params.search_workspace(params, meta)
+    result = search(params, meta)
+    result = convert_result.search_workspace(result, params, meta)
+    logger.debug(f"Finished 'search_workspace' method in {time.time() - start}s")
+    return result
+
+
 service.add(show_indexes)
 service.add(show_config)
 service.add(search_objects)
+service.add(search_workspace)

--- a/tests/helpers/integration_setup.py
+++ b/tests/helpers/integration_setup.py
@@ -1,0 +1,29 @@
+import os
+import subprocess
+
+
+def setup():
+    if os.environ.get("SKIP_DOCKER"):
+        return
+    ES_URL = os.environ.get("ES_URL", "http://localhost:9500")
+    # TOKEN = os.environ["TOKEN"]
+    INDEX_PREFIX = os.environ.get('INDEX_PREFIX', 'search2')
+    USER_PROFILE_URL = os.environ.get('USER_PROFILE_URL', 'https://ci.kbase.us/services/user_profile')
+    WS_URL = os.environ.get('WS_URL', 'https://ci.kbase.us/services/ws')
+    IMAGE_NAME = "kbase/search2"
+    # Build and start the app using docker
+    cmd = f"""
+    docker build . -t {IMAGE_NAME} && \\
+    docker run -e ELASTICSEARCH_URL={ES_URL} \\
+               -e WORKSPACE_URL={WS_URL} \\
+               -e USER_PROFILE_URL={USER_PROFILE_URL} \\
+               -e WORKERS=2 \\
+               -e INDEX_PREFIX={INDEX_PREFIX} \\
+               -e INDEX_PREFIX_DELIMITER=. \\
+               -e DEVELOPMENT=1 \\
+               -p 5000:5000 \\
+               --network host \\
+               {IMAGE_NAME}
+    """
+    print(f'Running command:\n{cmd}')
+    subprocess.Popen(cmd, shell=True)

--- a/tests/integration/test_integration_legacy.py
+++ b/tests/integration/test_integration_legacy.py
@@ -1,8 +1,8 @@
 import json
 import os
 import requests
-import subprocess
 
+from tests.helpers.integration_setup import setup
 from src.utils.wait_for_service import wait_for_service
 from tests.integration.data import (
     search_request1,
@@ -18,36 +18,11 @@ from tests.integration.data import (
 )
 
 
-APP_URL = os.environ.get("APP_URL", 'http://localhost:5001')
+APP_URL = os.environ.get("APP_URL", 'http://localhost:5000')
 
-if not os.environ.get("SKIP_DOCKER"):
-    ES_URL = os.environ.get("ES_URL", "http://localhost:9500")
-    # TOKEN = os.environ["TOKEN"]
-    INDEX_PREFIX = os.environ.get('INDEX_PREFIX', 'search2')
-    USER_PROFILE_URL = os.environ.get('USER_PROFILE_URL', 'https://ci.kbase.us/services/user_profile')
-    WS_URL = os.environ.get('WS_URL', 'https://ci.kbase.us/services/ws')
-    IMAGE_NAME = "kbase/search2"
-    # Build and start the app using docker
-    cmd = f"""
-    docker build . -t {IMAGE_NAME} && \\
-    docker run -e ELASTICSEARCH_URL={ES_URL} \\
-               -e WORKSPACE_URL={WS_URL} \\
-               -e USER_PROFILE_URL={USER_PROFILE_URL} \\
-               -e WORKERS=2 \\
-               -e INDEX_PREFIX={INDEX_PREFIX} \\
-               -e INDEX_PREFIX_DELIMITER=. \\
-               -e DEVELOPMENT=1 \\
-               --network host \\
-               {IMAGE_NAME}
-    """
-    print(f'Running command:\n{cmd}')
-    subprocess.Popen(cmd, shell=True)
-
+setup()
 # This implicitly tests the "/" path
 wait_for_service(APP_URL, "search2")
-
-
-# TODO old api seems to have default sort on timestamp -- do we want this?
 
 
 def test_search_example1():

--- a/tests/integration/test_integration_search_workspaces.py
+++ b/tests/integration/test_integration_search_workspaces.py
@@ -1,0 +1,45 @@
+import json
+import os
+import requests
+
+from tests.helpers.integration_setup import setup
+from src.utils.wait_for_service import wait_for_service
+
+
+APP_URL = os.environ.get("APP_URL", 'http://localhost:5000')
+setup()
+
+# This implicitly tests the "/" path
+wait_for_service(APP_URL, "search2")
+
+
+def test_narrative_example():
+    params = {
+        "access": {
+            "only_public": True,
+        },
+        "types": ["KBaseGenomes.Genome"],
+        "search": {
+            "query": "escherichia coli",
+            "fields": ["agg_fields", "scientific_name"]
+        },
+        "filters": {
+            "field": "source", "term": "refseq"
+        },
+        "paging": {
+            "length": 10,
+            "offset": 0
+        }
+    }
+    url = APP_URL + '/rpc'
+    resp = requests.post(
+        url=url,
+        data=json.dumps({
+            "method": "search_workspace",
+            "jsonrpc": "2.0",
+            "id": 0,
+            "params": params
+        })
+    )
+    data = resp.json()
+    print("DATA", data)

--- a/tests/integration/test_integration_search_workspaces.py
+++ b/tests/integration/test_integration_search_workspaces.py
@@ -24,7 +24,7 @@ def test_narrative_example():
             "fields": ["agg_fields", "scientific_name"]
         },
         "filters": {
-            "field": "source", "term": "refseq"
+            "field": "tags", "term": "refdata"
         },
         "paging": {
             "length": 10,
@@ -42,4 +42,4 @@ def test_narrative_example():
         })
     )
     data = resp.json()
-    print("DATA", data)
+    assert data['result']['count'] > 0

--- a/tests/unit/es_client/test_es_client.py
+++ b/tests/unit/es_client/test_es_client.py
@@ -19,7 +19,7 @@ init_elasticsearch()
 
 def test_search_public_valid():
     params = {
-        'public_only': True,
+        'only_public': True,
         'track_total_hits': True,
     }
     result = search(params, {'auth': None})
@@ -38,7 +38,7 @@ def test_search_public_valid():
 
 def test_search_query_valid():
     params = {
-        'public_only': True,
+        'only_public': True,
         'query': {
             "term": {"name": "doc2"},
         },
@@ -116,7 +116,7 @@ def test_search_unknown_index():
 def test_search_private_valid():
     with patch('src.es_client.query.ws_auth') as mocked:
         mocked.return_value = [1, 2, 3]  # Authorized workspaces
-        params = {'private_only': True}
+        params = {'only_private': True}
         result = search(params, {'auth': 'x'})
         assert result['count'] == 2
         names = {hit['doc']['name'] for hit in result['hits']}
@@ -128,6 +128,6 @@ def test_search_private_valid():
 def test_search_private_no_access():
     with patch('src.es_client.query.ws_auth') as mocked:
         mocked.return_value = [55]  # Authorized workspaces
-        params = {'private_only': True}
+        params = {'only_private': True}
         result = search(params, {'auth': 'x'})
         assert result['count'] == 0

--- a/tests/unit/search2_conversion/test_search2_convert_params.py
+++ b/tests/unit/search2_conversion/test_search2_convert_params.py
@@ -1,0 +1,70 @@
+from src.search2_conversion import convert_params
+
+# TODO Test invalid parameters
+
+
+def test_search_workspace():
+    """Simple test to cover all code paths with a valid result"""
+    params = {
+        'types': ['KBaseNarrative.Narrative'],
+        'include_fields': ['x', 'y'],
+        'search': {
+            'query': "foo | bar + baz*",
+            'fields': ['x', 'y'],
+        },
+        'sorts': [
+            ['x', 'desc'],
+            ['y', 'asc']
+        ],
+        'filters': {
+            'operator': 'AND',
+            'fields': [
+                {
+                    'operator': 'OR',
+                    'fields': [
+                        {'field': 'x', 'range': {'min': 10, 'max': 20}},
+                        {'field': 'y', 'not_term': 1}
+                    ]
+                },
+                {'field': 'x', 'term': 1}
+            ]
+        },
+        'paging': {
+            'length': 20,
+            'offset': 10
+        },
+        'access': {
+            'only_private': True
+        },
+        'track_total_hits': True
+    }
+    result = convert_params.search_workspace(params, {})
+    expected = {
+        "query": {
+            "simple_query_string": {
+                "fields": ["x", "y"],
+                "query": "foo | bar + baz*"
+            },
+            "bool": {
+                "must": [
+                    {
+                        "should": [
+                            {"range": {"x": {"lte": 20, "gte": 10}}},
+                            {"must_not": {"term": {"y": {"value": 1}}}}
+                        ]
+                    },
+                    {
+                        "term": {"x": {"value": 1}}
+                    }
+                ]
+            }
+        },
+        "only_public": False,
+        "only_private": True,
+        "track_total_hits": True,
+        "sort": [
+            {"x": {"order": "desc"}},
+            {"y": {"order": "asc"}}
+        ]
+    }
+    assert result == expected

--- a/tests/unit/search2_conversion/test_search2_convert_result.py
+++ b/tests/unit/search2_conversion/test_search2_convert_result.py
@@ -1,0 +1,16 @@
+from src.search2_conversion import convert_result
+
+
+def test_search2_convert_result_valid():
+    """Basic test."""
+    result = {
+        "search_time": 10,
+        "count": 11,
+        "hits": [{"doc": "hi"}, {"doc": "there"}],
+    }
+    params = {}
+    meta = {}
+    converted = convert_result.search_workspace(result, params, meta)
+    assert converted["search_time"] == result["search_time"]
+    assert converted["count"] == result["count"]
+    assert converted["hits"] == ["hi", "there"]

--- a/tests/unit/search2_rpc/test_search2_rpc.py
+++ b/tests/unit/search2_rpc/test_search2_rpc.py
@@ -49,3 +49,18 @@ def test_search_objects():
     result = service.call(json.dumps(params), {'auth': None})
     res = json.loads(result)
     assert res['result']['count'] > 0
+
+
+def test_search_workspace():
+    params = {
+        "method": "search_workspace",
+        "jsonrpc": "2.0",
+        "id": 0,
+        "params": {
+            "types": ["KBaseNarrative.Narrative"]
+        }
+    }
+    result = service.call(json.dumps(params), {'auth': None})
+    res = json.loads(result)
+    assert 'error' not in res
+    assert res['result']['count'] > 0

--- a/tests/unit/utils/test_obj_utils.py
+++ b/tests/unit/utils/test_obj_utils.py
@@ -1,0 +1,31 @@
+from src.utils.obj_utils import get_path, get_any
+
+
+def test_get_path_valid():
+    obj = {'x': {'y': [1, {'z': 'hi'}]}}
+    res = get_path(obj, ['x', 'y', 1, 'z'])
+    assert res == 'hi'
+
+
+def test_get_path_none():
+    obj = {'x': {'y': [1, {'z': 'hi'}]}}
+    res = get_path(obj, ['x', 'z'])
+    assert res is None
+
+
+def test_get_any_valid():
+    obj = {'x': 0, 'y': 1, 'z': 2}
+    res = get_any(obj, ['x', 'q'])
+    assert res == 0
+
+
+def test_get_any_valid2():
+    obj = {'x': 0, 'y': 1, 'z': 2}
+    res = get_any(obj, ['q'], 'hi')
+    assert res == 'hi'
+
+
+def test_get_any_valid3():
+    obj = {'x': 0, 'y': 1, 'z': 2}
+    res = get_any(obj, ['q', 'y', 'z'], 'hi')
+    assert res == 1


### PR DESCRIPTION
* More abstracted from the ES query API
* Still very generalized, and should be powerful enough to cover UI cases
* Allows us to deprecate previous methods such as rpc/search_objects, legacy/search_objects, legacy/get_objects