### PR TITLE
Fixes SCT-2930

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,14 @@ test:
 
 build-integration-test-images:
 	@echo Building integration test images...
-	cd tests/integration/docker
-	docker-compose build
-	cd ../../..
+	sh scripts/build-integration-test-images.sh
 	@echo Integration test images built
 
 integration-tests: 
-	@echo Running Integraion Tests...
+	@echo Running Integration Tests...
 	sh scripts/run_integration_tests
+
+run-dev-server:
+	@echo Starting dev server...
+	sh scripts/run-dev-server.sh
+

--- a/docs/ez-guide.md
+++ b/docs/ez-guide.md
@@ -56,7 +56,7 @@ or
 sh scripts/run_tests
 ```
 
-## Integration Tests
+## Integration Testing
 
 The integration tests run inside a Docker container. An associated ssh tunnel proxies elastic search requests into KBase. This tunnel is also run in a container. To ease the process of coordinating the startup of these containers, the are scripted in a docker-compose config file.
 
@@ -65,7 +65,7 @@ The integration tests run inside a Docker container. An associated ssh tunnel pr
 Although the integration test script will build the images if they are missing, the build can take a few minutes, which may cause the integration test script to time out. It is more reliable to simply build the containers first.
 
 ```bash
-make build-integration-test-images
+make build-integration-test-images.sh
 ```
 
 You can view the files `container.out` and `container.err` to monitor progress building the images.
@@ -133,4 +133,10 @@ tests/integration/test_integration_search_workspaces.py::test_dashboard_example 
 
 =================================================== 9 passed in 24.27s ====================================================
 (venv) erikpearson@Eriks-MBP-2 search_api2 %
+``
+
+## Using with kbase-ui
+
+```
+IP="<IP HERE>" SSHHOST="login1.berkeley.kbase.us" SSHUSER="<KBASE DEV USERNAME>" SSHPASS="<KBASE DEV PWD>" docker-compose --file tests/integration/docker-compose.yaml up
 ```

--- a/docs/ez-guide.md
+++ b/docs/ez-guide.md
@@ -28,8 +28,10 @@ poetry install
 
 Run the tests!
 
+This will run all the unit tests plus associated code quality evaluations.
+
 ```sh
-sh scripts/run_tests
+make test
 ```
 
 To run tests in a given directory or individual test modules:
@@ -42,18 +44,6 @@ e.g. to run all the `es_client` tests:
 
 ```sh
 WORKSPACE_URL="http://localhost:5555/ws" PYTHONPATH=. poetry run pytest -vv tests/unit/es_client
-```
-
-And to run all the unit tests plus associated code quality evaluations:
-
-```sh
-make test
-```
-
-or
-
-```sh
-sh scripts/run_tests
 ```
 
 ## Integration Testing

--- a/docs/integration-testing.md
+++ b/docs/integration-testing.md
@@ -7,7 +7,7 @@ The integration tests run inside a Docker container. An associated ssh tunnel pr
 Although the integration test script will build the images if they are missing, the build can take a few minutes, which may cause the integration test script to time out. It is more reliable to simply build the containers first.
 
 ```bash
-make build-integration-test-images
+make build-integration-test-images.sh
 ```
 
 You can view the files `container.out` and `container.err` to monitor progress building the images.

--- a/legacy-schema.yaml
+++ b/legacy-schema.yaml
@@ -358,11 +358,19 @@ definitions:
 
   accessFilter:
     type: object
-    required: []
-    additionalProperties: false
-    properties:
-      with_private: {$ref: "#/definitions/sdk_boolean"}
-      with_public: {$ref: "#/definitions/sdk_boolean"}
+    allOf:
+      # This gives a more explicit reason for failing.
+      - not:
+          required: []
+          properties:
+            with_private:
+              const: 0
+            with_public:
+              const: 0
+      - required: []
+        properties:
+          with_private: {$ref: "#/definitions/sdk_boolean"}
+          with_public: {$ref: "#/definitions/sdk_boolean"}
 
   matchFilter:
     type: object

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,178 +1,173 @@
 [[package]]
-category = "main"
-description = "File support for asyncio."
 name = "aiofiles"
+version = "0.6.0"
+description = "File support for asyncio."
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.5.0"
 
 [[package]]
-category = "dev"
-description = "Atomic file writes."
-marker = "sys_platform == \"win32\""
 name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.4.0"
 
 [[package]]
-category = "main"
-description = "Classes Without Boilerplate"
 name = "attrs"
+version = "20.3.0"
+description = "Classes Without Boilerplate"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.3.0"
 
 [package.extras]
-azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
-dev = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "pre-commit"]
-docs = ["sphinx", "zope.interface"]
-tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
-category = "dev"
-description = "Security oriented static analyser for python code."
 name = "bandit"
+version = "1.7.0"
+description = "Security oriented static analyser for python code."
+category = "dev"
 optional = false
-python-versions = "*"
-version = "1.6.2"
+python-versions = ">=3.5"
 
 [package.dependencies]
+colorama = {version = ">=0.3.9", markers = "platform_system == \"Windows\""}
 GitPython = ">=1.0.1"
-PyYAML = ">=3.13"
-colorama = ">=0.3.9"
+PyYAML = ">=5.3.1"
 six = ">=1.10.0"
 stevedore = ">=1.20.0"
 
 [[package]]
-category = "main"
-description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
-optional = false
-python-versions = "*"
-version = "2020.6.20"
-
-[[package]]
+version = "2020.12.5"
+description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
-description = "Universal encoding detector for Python 2 and 3"
-name = "chardet"
 optional = false
 python-versions = "*"
-version = "3.0.4"
 
 [[package]]
-category = "dev"
-description = "Cross-platform colored terminal text."
-marker = "platform_system == \"Windows\" or sys_platform == \"win32\""
+name = "chardet"
+version = "3.0.4"
+description = "Universal encoding detector for Python 2 and 3"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.3"
 
 [[package]]
-category = "dev"
-description = "Code coverage measurement for Python"
 name = "coverage"
+version = "5.5"
+description = "Code coverage measurement for Python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "5.2.1"
 
 [package.extras]
 toml = ["toml"]
 
 [[package]]
-category = "dev"
-description = "the modular source code checker: pep8 pyflakes and co"
 name = "flake8"
+version = "3.8.4"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "3.8.3"
 
 [package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.6.0a1,<2.7.0"
 pyflakes = ">=2.2.0,<2.3.0"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = "*"
-
 [[package]]
-category = "dev"
-description = "Git Object Database"
 name = "gitdb"
+version = "4.0.5"
+description = "Git Object Database"
+category = "dev"
 optional = false
 python-versions = ">=3.4"
-version = "4.0.5"
 
 [package.dependencies]
 smmap = ">=3.0.1,<4"
 
 [[package]]
-category = "dev"
-description = "Python Git Library"
 name = "gitpython"
+version = "3.1.14"
+description = "Python Git Library"
+category = "dev"
 optional = false
 python-versions = ">=3.4"
-version = "3.1.7"
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
 
 [[package]]
-category = "main"
-description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 name = "h11"
+version = "0.9.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.9.0"
 
 [[package]]
-category = "main"
-description = "HTTP/2 State-Machine based protocol implementation"
 name = "h2"
+version = "3.2.0"
+description = "HTTP/2 State-Machine based protocol implementation"
+category = "main"
 optional = false
 python-versions = "*"
-version = "3.2.0"
 
 [package.dependencies]
 hpack = ">=3.0,<4"
 hyperframe = ">=5.2.0,<6"
 
 [[package]]
-category = "main"
-description = "Pure-Python HPACK header compression"
 name = "hpack"
+version = "3.0.0"
+description = "Pure-Python HPACK header compression"
+category = "main"
 optional = false
 python-versions = "*"
-version = "3.0.0"
 
 [[package]]
-category = "main"
-description = "Chromium HSTS Preload list as a Python package and updated daily"
 name = "hstspreload"
+version = "2020.12.22"
+description = "Chromium HSTS Preload list as a Python package"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "2020.8.18"
 
 [[package]]
-category = "main"
-description = "A collection of framework independent HTTP protocol utils."
 name = "httptools"
+version = "0.1.1"
+description = "A collection of framework independent HTTP protocol utils."
+category = "main"
 optional = false
 python-versions = "*"
-version = "0.1.1"
 
 [package.extras]
-test = ["Cython (0.29.14)"]
+test = ["Cython (==0.29.14)"]
 
 [[package]]
-category = "main"
-description = "The next generation HTTP client."
 name = "httpx"
+version = "0.11.1"
+description = "The next generation HTTP client."
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "0.11.1"
 
 [package.dependencies]
 certifi = "*"
@@ -186,102 +181,98 @@ sniffio = ">=1.0.0,<2.0.0"
 urllib3 = ">=1.0.0,<2.0.0"
 
 [[package]]
-category = "main"
-description = "HTTP/2 framing layer for Python"
 name = "hyperframe"
+version = "5.2.0"
+description = "HTTP/2 framing layer for Python"
+category = "main"
 optional = false
 python-versions = "*"
-version = "5.2.0"
 
 [[package]]
-category = "main"
-description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
+version = "2.10"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.10"
 
 [[package]]
-category = "main"
-description = "Read metadata from Python packages"
-marker = "python_version < \"3.8\""
 name = "importlib-metadata"
+version = "3.7.0"
+description = "Read metadata from Python packages"
+category = "main"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.7.0"
+python-versions = ">=3.6"
 
 [package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
-category = "main"
-description = "An implementation of JSON Schema validation for Python"
 name = "jsonschema"
+version = "3.2.0"
+description = "An implementation of JSON Schema validation for Python"
+category = "main"
 optional = false
 python-versions = "*"
-version = "3.2.0"
 
 [package.dependencies]
 attrs = ">=17.4.0"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 pyrsistent = ">=0.14.0"
-setuptools = "*"
 six = ">=1.11.0"
-
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = "*"
 
 [package.extras]
 format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
 format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator (>0.1.0)", "rfc3339-validator"]
 
 [[package]]
-category = "main"
-description = "Simple JSON-RPC service without transport layer"
 name = "kbase-jsonrpcbase"
+version = "0.3.0a6"
+description = "Simple JSON-RPC service without transport layer"
+category = "main"
 optional = false
 python-versions = ">=3.6,<4.0"
-version = "0.3.0a6"
 
 [package.dependencies]
 jsonschema = ">=3.2.0,<4.0.0"
 pyyaml = ">=5.3.1,<6.0.0"
 
 [[package]]
-category = "dev"
-description = "McCabe checker, plugin for flake8"
 name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.6.1"
 
 [[package]]
-category = "dev"
-description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
-optional = false
-python-versions = ">=3.5"
-version = "8.4.0"
-
-[[package]]
-category = "main"
-description = "multidict implementation"
-name = "multidict"
-optional = false
-python-versions = ">=3.5"
-version = "4.7.6"
-
-[[package]]
+version = "8.7.0"
+description = "More routines for operating on iterables, beyond itertools"
 category = "dev"
-description = "Optional static typing for Python"
-name = "mypy"
 optional = false
 python-versions = ">=3.5"
+
+[[package]]
+name = "multidict"
+version = "4.7.6"
+description = "multidict implementation"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "mypy"
 version = "0.782"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3,<0.5.0"
@@ -292,148 +283,139 @@ typing-extensions = ">=3.7.4"
 dmypy = ["psutil (>=4.0)"]
 
 [[package]]
-category = "dev"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
 name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.4.3"
 
 [[package]]
-category = "dev"
-description = "Core utilities for Python packages"
 name = "packaging"
+version = "20.9"
+description = "Core utilities for Python packages"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.4"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
-six = "*"
 
 [[package]]
-category = "dev"
-description = "Python Build Reasonableness"
 name = "pbr"
+version = "5.5.1"
+description = "Python Build Reasonableness"
+category = "dev"
 optional = false
-python-versions = "*"
-version = "5.4.5"
+python-versions = ">=2.6"
 
 [[package]]
-category = "dev"
-description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.1"
 
 [package.dependencies]
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
 
 [[package]]
-category = "dev"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
+version = "1.10.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.9.0"
 
 [[package]]
-category = "dev"
-description = "Python style guide checker"
 name = "pycodestyle"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.6.0"
-
-[[package]]
+description = "Python style guide checker"
 category = "dev"
-description = "passive checker of Python programs"
-name = "pyflakes"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.2.0"
 
 [[package]]
+name = "pyflakes"
+version = "2.2.0"
+description = "passive checker of Python programs"
 category = "dev"
-description = "Python parsing module"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.7"
 
 [[package]]
-category = "main"
-description = "Persistent/Functional/Immutable data structures"
 name = "pyrsistent"
-optional = false
-python-versions = "*"
-version = "0.16.0"
-
-[package.dependencies]
-six = "*"
-
-[[package]]
-category = "dev"
-description = "pytest: simple powerful testing with Python"
-name = "pytest"
+version = "0.17.3"
+description = "Persistent/Functional/Immutable data structures"
+category = "main"
 optional = false
 python-versions = ">=3.5"
+
+[[package]]
+name = "pytest"
 version = "5.4.3"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
 
 [package.dependencies]
-atomicwrites = ">=1.0"
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=17.4.0"
-colorama = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 more-itertools = ">=4.0.0"
 packaging = "*"
 pluggy = ">=0.12,<1.0"
 py = ">=1.5.0"
 wcwidth = "*"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
-
 [package.extras]
-checkqa-mypy = ["mypy (v0.761)"]
+checkqa-mypy = ["mypy (==v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-category = "dev"
-description = "Pytest plugin for measuring coverage."
 name = "pytest-cov"
+version = "2.11.1"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.10.1"
 
 [package.dependencies]
-coverage = ">=4.4"
+coverage = ">=5.2.1"
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
-category = "main"
-description = "YAML parser and emitter for Python"
 name = "pyyaml"
+version = "5.3.1"
+description = "YAML parser and emitter for Python"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "5.3.1"
 
 [[package]]
-category = "main"
-description = "Python HTTP for Humans."
 name = "requests"
+version = "2.24.0"
+description = "Python HTTP for Humans."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.24.0"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -443,15 +425,15 @@ urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 
 [[package]]
-category = "dev"
-description = "A utility library for mocking out the `requests` Python library."
 name = "responses"
+version = "0.12.1"
+description = "A utility library for mocking out the `requests` Python library."
+category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.10.16"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
 requests = ">=2.0"
@@ -459,237 +441,255 @@ six = "*"
 urllib3 = ">=1.25.10"
 
 [package.extras]
-tests = ["coverage (>=3.7.1,<5.0.0)", "pytest-cov", "pytest-localserver", "flake8", "pytest (>=4.6,<5.0)", "pytest (>=4.6)"]
+tests = ["coverage (>=3.7.1,<6.0.0)", "pytest-cov", "pytest-localserver", "flake8", "pytest (>=4.6,<5.0)", "pytest (>=4.6)"]
 
 [[package]]
-category = "main"
-description = "Validating URI References per RFC 3986"
 name = "rfc3986"
+version = "1.4.0"
+description = "Validating URI References per RFC 3986"
+category = "main"
 optional = false
 python-versions = "*"
-version = "1.4.0"
 
 [package.extras]
 idna2008 = ["idna"]
 
 [[package]]
-category = "main"
-description = "A web server and web framework that's written to go fast. Build fast. Run fast."
 name = "sanic"
+version = "20.6.3"
+description = "A web server and web framework that's written to go fast. Build fast. Run fast."
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "20.6.3"
 
 [package.dependencies]
 aiofiles = ">=0.3.0"
 httptools = ">=0.0.10"
 httpx = "0.11.1"
 multidict = ">=4.0,<5.0"
-ujson = ">=1.35"
-uvloop = ">=0.5.3"
+ujson = {version = ">=1.35", markers = "sys_platform != \"win32\" and implementation_name == \"cpython\""}
+uvloop = {version = ">=0.5.3", markers = "sys_platform != \"win32\" and implementation_name == \"cpython\""}
 websockets = ">=8.1,<9.0"
 
 [package.extras]
-all = ["pytest (5.2.1)", "multidict (>=4.0,<5.0)", "gunicorn", "pytest-cov", "httpcore (0.3.0)", "beautifulsoup4", "pytest-sanic", "pytest-sugar", "pytest-benchmark", "aiofiles", "tox", "black", "flake8", "bandit", "towncrier", "sphinx (>=2.1.2)", "sphinx-rtd-theme", "recommonmark (>=0.5.0)", "docutils", "pygments", "uvloop (>=0.5.3)", "ujson (>=1.35)"]
-dev = ["pytest (5.2.1)", "multidict (>=4.0,<5.0)", "gunicorn", "pytest-cov", "httpcore (0.3.0)", "beautifulsoup4", "pytest-sanic", "pytest-sugar", "pytest-benchmark", "aiofiles", "tox", "black", "flake8", "bandit", "towncrier", "uvloop (>=0.5.3)", "ujson (>=1.35)"]
+all = ["pytest (==5.2.1)", "multidict (>=4.0,<5.0)", "gunicorn", "pytest-cov", "httpcore (==0.3.0)", "beautifulsoup4", "pytest-sanic", "pytest-sugar", "pytest-benchmark", "aiofiles", "tox", "black", "flake8", "bandit", "towncrier", "sphinx (>=2.1.2)", "sphinx-rtd-theme", "recommonmark (>=0.5.0)", "docutils", "pygments", "uvloop (>=0.5.3)", "ujson (>=1.35)"]
+dev = ["pytest (==5.2.1)", "multidict (>=4.0,<5.0)", "gunicorn", "pytest-cov", "httpcore (==0.3.0)", "beautifulsoup4", "pytest-sanic", "pytest-sugar", "pytest-benchmark", "aiofiles", "tox", "black", "flake8", "bandit", "towncrier", "uvloop (>=0.5.3)", "ujson (>=1.35)"]
 docs = ["sphinx (>=2.1.2)", "sphinx-rtd-theme", "recommonmark (>=0.5.0)", "docutils", "pygments"]
-test = ["pytest (5.2.1)", "multidict (>=4.0,<5.0)", "gunicorn", "pytest-cov", "httpcore (0.3.0)", "beautifulsoup4", "pytest-sanic", "pytest-sugar", "pytest-benchmark", "uvloop (>=0.5.3)", "ujson (>=1.35)"]
+test = ["pytest (==5.2.1)", "multidict (>=4.0,<5.0)", "gunicorn", "pytest-cov", "httpcore (==0.3.0)", "beautifulsoup4", "pytest-sanic", "pytest-sugar", "pytest-benchmark", "uvloop (>=0.5.3)", "ujson (>=1.35)"]
 
 [[package]]
-category = "main"
-description = "Python 2 and 3 compatibility utilities"
 name = "six"
+version = "1.15.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.15.0"
 
 [[package]]
-category = "dev"
-description = "A pure Python implementation of a sliding window memory map manager"
 name = "smmap"
+version = "3.0.5"
+description = "A pure Python implementation of a sliding window memory map manager"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.0.4"
 
 [[package]]
-category = "main"
-description = "Sniff out which async library your code is running under"
 name = "sniffio"
+version = "1.2.0"
+description = "Sniff out which async library your code is running under"
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "1.1.0"
 
 [[package]]
-category = "dev"
-description = "Manage dynamic plugins for Python applications"
 name = "stevedore"
+version = "3.3.0"
+description = "Manage dynamic plugins for Python applications"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
-version = "3.2.0"
 
 [package.dependencies]
+importlib-metadata = {version = ">=1.7.0", markers = "python_version < \"3.8\""}
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=1.7.0"
-
 [[package]]
-category = "dev"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
 name = "typed-ast"
-optional = false
-python-versions = "*"
-version = "1.4.1"
-
-[[package]]
+version = "1.4.2"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "dev"
-description = "Backported and Experimental Type Hints for Python 3.5+"
-name = "typing-extensions"
 optional = false
 python-versions = "*"
-version = "3.7.4.2"
 
 [[package]]
+name = "typing-extensions"
+version = "3.7.4.3"
+description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
-description = "Ultra fast JSON encoder and decoder for Python"
-marker = "sys_platform != \"win32\" and implementation_name == \"cpython\""
-name = "ujson"
 optional = false
-python-versions = ">=3.5"
-version = "3.1.0"
+python-versions = "*"
 
 [[package]]
+name = "ujson"
+version = "4.0.2"
+description = "Ultra fast JSON encoder and decoder for Python"
 category = "main"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "urllib3"
+version = "1.25.11"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.25.10"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-category = "main"
-description = "Fast implementation of asyncio event loop on top of libuv"
-marker = "sys_platform != \"win32\" and implementation_name == \"cpython\""
 name = "uvloop"
-optional = false
-python-versions = "*"
-version = "0.14.0"
-
-[[package]]
-category = "dev"
-description = "Measures the displayed width of unicode strings in a terminal"
-name = "wcwidth"
-optional = false
-python-versions = "*"
-version = "0.2.5"
-
-[[package]]
+version = "0.15.2"
+description = "Fast implementation of asyncio event loop on top of libuv"
 category = "main"
-description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+dev = ["Cython (>=0.29.20,<0.30.0)", "pytest (>=3.6.0)", "Sphinx (>=1.7.3,<1.8.0)", "sphinxcontrib-asyncio (>=0.2.0,<0.3.0)", "sphinx-rtd-theme (>=0.2.4,<0.3.0)", "aiohttp", "flake8 (>=3.8.4,<3.9.0)", "psutil", "pycodestyle (>=2.6.0,<2.7.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
+docs = ["Sphinx (>=1.7.3,<1.8.0)", "sphinxcontrib-asyncio (>=0.2.0,<0.3.0)", "sphinx-rtd-theme (>=0.2.4,<0.3.0)"]
+test = ["aiohttp", "flake8 (>=3.8.4,<3.9.0)", "psutil", "pycodestyle (>=2.6.0,<2.7.0)", "pyOpenSSL (>=19.0.0,<19.1.0)", "mypy (>=0.800)"]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.5"
+description = "Measures the displayed width of unicode strings in a terminal"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "websockets"
+version = "8.1"
+description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+category = "main"
 optional = false
 python-versions = ">=3.6.1"
-version = "8.1"
 
 [[package]]
-category = "main"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\""
 name = "zipp"
+version = "3.4.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "3.1.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["jaraco.itertools", "func-timeout"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "cf06b52175367937bad5dddfcec435b37246f216c8c666c27ff7975f093ed6b7"
+lock-version = "1.1"
 python-versions = "^3.7"
+content-hash = "01161e2209716b8268eb514e4690d740c3cdcc645b25d5299098a009b73ab414"
 
 [metadata.files]
 aiofiles = [
-    {file = "aiofiles-0.5.0-py3-none-any.whl", hash = "sha256:377fdf7815cc611870c59cbd07b68b180841d2a2b79812d8c218be02448c2acb"},
-    {file = "aiofiles-0.5.0.tar.gz", hash = "sha256:98e6bcfd1b50f97db4980e182ddd509b7cc35909e903a8fe50d8849e02d815af"},
+    {file = "aiofiles-0.6.0-py3-none-any.whl", hash = "sha256:bd3019af67f83b739f8e4053c6c0512a7f545b9a8d91aaeab55e6e0f9d123c27"},
+    {file = "aiofiles-0.6.0.tar.gz", hash = "sha256:e0281b157d3d5d59d803e3f4557dcc9a3dff28a4dd4829a9ff478adae50ca092"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
-    {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
+    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
+    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
 ]
 bandit = [
-    {file = "bandit-1.6.2-py2.py3-none-any.whl", hash = "sha256:336620e220cf2d3115877685e264477ff9d9abaeb0afe3dc7264f55fa17a3952"},
-    {file = "bandit-1.6.2.tar.gz", hash = "sha256:41e75315853507aa145d62a78a2a6c5e3240fe14ee7c601459d0df9418196065"},
+    {file = "bandit-1.7.0-py3-none-any.whl", hash = "sha256:216be4d044209fa06cf2a3e51b319769a51be8318140659719aa7a115c35ed07"},
+    {file = "bandit-1.7.0.tar.gz", hash = "sha256:8a4c7415254d75df8ff3c3b15cfe9042ecee628a1e40b44c15a98890fbfc2608"},
 ]
 certifi = [
-    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
-    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
+    {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
+    {file = "certifi-2020.12.5.tar.gz", hash = "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
     {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
 ]
 colorama = [
-    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
-    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-5.2.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:40f70f81be4d34f8d491e55936904db5c527b0711b2a46513641a5729783c2e4"},
-    {file = "coverage-5.2.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:675192fca634f0df69af3493a48224f211f8db4e84452b08d5fcebb9167adb01"},
-    {file = "coverage-5.2.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:2fcc8b58953d74d199a1a4d633df8146f0ac36c4e720b4a1997e9b6327af43a8"},
-    {file = "coverage-5.2.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:64c4f340338c68c463f1b56e3f2f0423f7b17ba6c3febae80b81f0e093077f59"},
-    {file = "coverage-5.2.1-cp27-cp27m-win32.whl", hash = "sha256:52f185ffd3291196dc1aae506b42e178a592b0b60a8610b108e6ad892cfc1bb3"},
-    {file = "coverage-5.2.1-cp27-cp27m-win_amd64.whl", hash = "sha256:30bc103587e0d3df9e52cd9da1dd915265a22fad0b72afe54daf840c984b564f"},
-    {file = "coverage-5.2.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:9ea749fd447ce7fb1ac71f7616371f04054d969d412d37611716721931e36efd"},
-    {file = "coverage-5.2.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ce7866f29d3025b5b34c2e944e66ebef0d92e4a4f2463f7266daa03a1332a651"},
-    {file = "coverage-5.2.1-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:4869ab1c1ed33953bb2433ce7b894a28d724b7aa76c19b11e2878034a4e4680b"},
-    {file = "coverage-5.2.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:a3ee9c793ffefe2944d3a2bd928a0e436cd0ac2d9e3723152d6fd5398838ce7d"},
-    {file = "coverage-5.2.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:28f42dc5172ebdc32622a2c3f7ead1b836cdbf253569ae5673f499e35db0bac3"},
-    {file = "coverage-5.2.1-cp35-cp35m-win32.whl", hash = "sha256:e26c993bd4b220429d4ec8c1468eca445a4064a61c74ca08da7429af9bc53bb0"},
-    {file = "coverage-5.2.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4186fc95c9febeab5681bc3248553d5ec8c2999b8424d4fc3a39c9cba5796962"},
-    {file = "coverage-5.2.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:b360d8fd88d2bad01cb953d81fd2edd4be539df7bfec41e8753fe9f4456a5082"},
-    {file = "coverage-5.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:1adb6be0dcef0cf9434619d3b892772fdb48e793300f9d762e480e043bd8e716"},
-    {file = "coverage-5.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:098a703d913be6fbd146a8c50cc76513d726b022d170e5e98dc56d958fd592fb"},
-    {file = "coverage-5.2.1-cp36-cp36m-win32.whl", hash = "sha256:962c44070c281d86398aeb8f64e1bf37816a4dfc6f4c0f114756b14fc575621d"},
-    {file = "coverage-5.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1ed2bdb27b4c9fc87058a1cb751c4df8752002143ed393899edb82b131e0546"},
-    {file = "coverage-5.2.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:c890728a93fffd0407d7d37c1e6083ff3f9f211c83b4316fae3778417eab9811"},
-    {file = "coverage-5.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:538f2fd5eb64366f37c97fdb3077d665fa946d2b6d95447622292f38407f9258"},
-    {file = "coverage-5.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:27ca5a2bc04d68f0776f2cdcb8bbd508bbe430a7bf9c02315cd05fb1d86d0034"},
-    {file = "coverage-5.2.1-cp37-cp37m-win32.whl", hash = "sha256:aab75d99f3f2874733946a7648ce87a50019eb90baef931698f96b76b6769a46"},
-    {file = "coverage-5.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:c2ff24df02a125b7b346c4c9078c8936da06964cc2d276292c357d64378158f8"},
-    {file = "coverage-5.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:304fbe451698373dc6653772c72c5d5e883a4aadaf20343592a7abb2e643dae0"},
-    {file = "coverage-5.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c96472b8ca5dc135fb0aa62f79b033f02aa434fb03a8b190600a5ae4102df1fd"},
-    {file = "coverage-5.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8505e614c983834239f865da2dd336dcf9d72776b951d5dfa5ac36b987726e1b"},
-    {file = "coverage-5.2.1-cp38-cp38-win32.whl", hash = "sha256:700997b77cfab016533b3e7dbc03b71d33ee4df1d79f2463a318ca0263fc29dd"},
-    {file = "coverage-5.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:46794c815e56f1431c66d81943fa90721bb858375fb36e5903697d5eef88627d"},
-    {file = "coverage-5.2.1-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:16042dc7f8e632e0dcd5206a5095ebd18cb1d005f4c89694f7f8aafd96dd43a3"},
-    {file = "coverage-5.2.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c1bbb628ed5192124889b51204de27c575b3ffc05a5a91307e7640eff1d48da4"},
-    {file = "coverage-5.2.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:4f6428b55d2916a69f8d6453e48a505c07b2245653b0aa9f0dee38785939f5e4"},
-    {file = "coverage-5.2.1-cp39-cp39-win32.whl", hash = "sha256:9e536783a5acee79a9b308be97d3952b662748c4037b6a24cbb339dc7ed8eb89"},
-    {file = "coverage-5.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:b8f58c7db64d8f27078cbf2a4391af6aa4e4767cc08b37555c4ae064b8558d9b"},
-    {file = "coverage-5.2.1.tar.gz", hash = "sha256:a34cb28e0747ea15e82d13e14de606747e9e484fb28d63c999483f5d5188e89b"},
+    {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90"},
+    {file = "coverage-5.5-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c"},
+    {file = "coverage-5.5-cp27-cp27m-win32.whl", hash = "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a"},
+    {file = "coverage-5.5-cp27-cp27m-win_amd64.whl", hash = "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5"},
+    {file = "coverage-5.5-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81"},
+    {file = "coverage-5.5-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6"},
+    {file = "coverage-5.5-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0"},
+    {file = "coverage-5.5-cp310-cp310-win_amd64.whl", hash = "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae"},
+    {file = "coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701"},
+    {file = "coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793"},
+    {file = "coverage-5.5-cp35-cp35m-win32.whl", hash = "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e"},
+    {file = "coverage-5.5-cp35-cp35m-win_amd64.whl", hash = "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3"},
+    {file = "coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb"},
+    {file = "coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821"},
+    {file = "coverage-5.5-cp36-cp36m-win32.whl", hash = "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45"},
+    {file = "coverage-5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184"},
+    {file = "coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638"},
+    {file = "coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3"},
+    {file = "coverage-5.5-cp37-cp37m-win32.whl", hash = "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a"},
+    {file = "coverage-5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a"},
+    {file = "coverage-5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2"},
+    {file = "coverage-5.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873"},
+    {file = "coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a"},
+    {file = "coverage-5.5-cp38-cp38-win32.whl", hash = "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6"},
+    {file = "coverage-5.5-cp38-cp38-win_amd64.whl", hash = "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502"},
+    {file = "coverage-5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529"},
+    {file = "coverage-5.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff"},
+    {file = "coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b"},
+    {file = "coverage-5.5-cp39-cp39-win32.whl", hash = "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6"},
+    {file = "coverage-5.5-cp39-cp39-win_amd64.whl", hash = "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03"},
+    {file = "coverage-5.5-pp36-none-any.whl", hash = "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079"},
+    {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
+    {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
 flake8 = [
-    {file = "flake8-3.8.3-py2.py3-none-any.whl", hash = "sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c"},
-    {file = "flake8-3.8.3.tar.gz", hash = "sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208"},
+    {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
+    {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
 ]
 gitdb = [
     {file = "gitdb-4.0.5-py3-none-any.whl", hash = "sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac"},
     {file = "gitdb-4.0.5.tar.gz", hash = "sha256:c9e1f2d0db7ddb9a704c2a0217be31214e91a4fe1dea1efad19ae42ba0c285c9"},
 ]
 gitpython = [
-    {file = "GitPython-3.1.7-py3-none-any.whl", hash = "sha256:fa3b92da728a457dd75d62bb5f3eb2816d99a7fe6c67398e260637a40e3fafb5"},
-    {file = "GitPython-3.1.7.tar.gz", hash = "sha256:2db287d71a284e22e5c2846042d0602465c7434d910406990d5b74df4afb0858"},
+    {file = "GitPython-3.1.14-py3-none-any.whl", hash = "sha256:3283ae2fba31c913d857e12e5ba5f9a7772bbc064ae2bb09efafa71b0dd4939b"},
+    {file = "GitPython-3.1.14.tar.gz", hash = "sha256:be27633e7509e58391f10207cd32b2a6cf5b908f92d9cd30da2e514e1137af61"},
 ]
 h11 = [
     {file = "h11-0.9.0-py2.py3-none-any.whl", hash = "sha256:4bc6d6a1238b7615b266ada57e0618568066f57dd6fa967d1290ec9309b2f2f1"},
@@ -704,8 +704,8 @@ hpack = [
     {file = "hpack-3.0.0.tar.gz", hash = "sha256:8eec9c1f4bfae3408a3f30500261f7e6a65912dc138526ea054f9ad98892e9d2"},
 ]
 hstspreload = [
-    {file = "hstspreload-2020.8.18-py3-none-any.whl", hash = "sha256:5e3b6b2376c6f412086ee21cdd29cd5e0af5b28c967e5f1f026323d0f31dc84b"},
-    {file = "hstspreload-2020.8.18.tar.gz", hash = "sha256:13cf2e9fcd064cd81d220432de9a66dd7e4f10862a03574c45e5f61fc522f312"},
+    {file = "hstspreload-2020.12.22-py3-none-any.whl", hash = "sha256:f09afa7015257d33ead35137ddfee3604040b7f9eefbe995dacb4d04744f4034"},
+    {file = "hstspreload-2020.12.22.tar.gz", hash = "sha256:8bd8cdf180627e6289805efad5399a55bedf2e707fdcbb243b74298b95db48c6"},
 ]
 httptools = [
     {file = "httptools-0.1.1-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:a2719e1d7a84bb131c4f1e0cb79705034b48de6ae486eb5297a139d6a3296dce"},
@@ -734,8 +734,8 @@ idna = [
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.7.0-py2.py3-none-any.whl", hash = "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"},
-    {file = "importlib_metadata-1.7.0.tar.gz", hash = "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83"},
+    {file = "importlib_metadata-3.7.0-py3-none-any.whl", hash = "sha256:c6af5dbf1126cd959c4a8d8efd61d4d3c83bddb0459a17e554284a077574b614"},
+    {file = "importlib_metadata-3.7.0.tar.gz", hash = "sha256:24499ffde1b80be08284100393955842be4a59c7c16bbf2738aad0e464a8e0aa"},
 ]
 jsonschema = [
     {file = "jsonschema-3.2.0-py2.py3-none-any.whl", hash = "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163"},
@@ -750,8 +750,8 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.4.0.tar.gz", hash = "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5"},
-    {file = "more_itertools-8.4.0-py3-none-any.whl", hash = "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"},
+    {file = "more-itertools-8.7.0.tar.gz", hash = "sha256:c5d6da9ca3ff65220c3bfd2a8db06d698f05d4d2b9be57e1deb2be5a45019713"},
+    {file = "more_itertools-8.7.0-py3-none-any.whl", hash = "sha256:5652a9ac72209ed7df8d9c15daf4e1aa0e3d2ccd3c87f8265a0673cd9cbc9ced"},
 ]
 multidict = [
     {file = "multidict-4.7.6-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:275ca32383bc5d1894b6975bb4ca6a7ff16ab76fa622967625baeebcf8079000"},
@@ -793,20 +793,20 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 packaging = [
-    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
-    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
+    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
+    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
 ]
 pbr = [
-    {file = "pbr-5.4.5-py2.py3-none-any.whl", hash = "sha256:579170e23f8e0c2f24b0de612f71f648eccb79fb1322c814ae6b3c07b5ba23e8"},
-    {file = "pbr-5.4.5.tar.gz", hash = "sha256:07f558fece33b05caf857474a366dfcc00562bca13dd8b47b2b3e22d9f9bf55c"},
+    {file = "pbr-5.5.1-py2.py3-none-any.whl", hash = "sha256:b236cde0ac9a6aedd5e3c34517b423cd4fd97ef723849da6b0d2231142d89c00"},
+    {file = "pbr-5.5.1.tar.gz", hash = "sha256:5fad80b613c402d5b7df7bd84812548b2a61e9977387a80a5fc5c396492b13c9"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 py = [
-    {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
-    {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
+    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
+    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
@@ -821,15 +821,15 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pyrsistent = [
-    {file = "pyrsistent-0.16.0.tar.gz", hash = "sha256:28669905fe725965daa16184933676547c5bb40a5153055a8dee2a4bd7933ad3"},
+    {file = "pyrsistent-0.17.3.tar.gz", hash = "sha256:2e636185d9eb976a18a8a8e96efce62f2905fea90041958d8cc2a189756ebf3e"},
 ]
 pytest = [
     {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
     {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
 ]
 pytest-cov = [
-    {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},
-    {file = "pytest_cov-2.10.1-py2.py3-none-any.whl", hash = "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191"},
+    {file = "pytest-cov-2.11.1.tar.gz", hash = "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7"},
+    {file = "pytest_cov-2.11.1-py2.py3-none-any.whl", hash = "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"},
 ]
 pyyaml = [
     {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
@@ -842,6 +842,8 @@ pyyaml = [
     {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
     {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
     {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
+    {file = "PyYAML-5.3.1-cp39-cp39-win32.whl", hash = "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a"},
+    {file = "PyYAML-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e"},
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 requests = [
@@ -849,8 +851,8 @@ requests = [
     {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
 ]
 responses = [
-    {file = "responses-0.10.16-py2.py3-none-any.whl", hash = "sha256:cf55b7c89fc77b9ebbc5e5924210b6d0ef437061b80f1273d7e202069e43493c"},
-    {file = "responses-0.10.16.tar.gz", hash = "sha256:fa125311607ab3e57d8fcc4da20587f041b4485bdfb06dd6bdf19d8b66f870c1"},
+    {file = "responses-0.12.1-py2.py3-none-any.whl", hash = "sha256:ef265bd3200bdef5ec17912fc64a23570ba23597fd54ca75c18650fa1699213d"},
+    {file = "responses-0.12.1.tar.gz", hash = "sha256:2e5764325c6b624e42b428688f2111fea166af46623cb0127c05f6afb14d3457"},
 ]
 rfc3986 = [
     {file = "rfc3986-1.4.0-py2.py3-none-any.whl", hash = "sha256:af9147e9aceda37c91a05f4deb128d4b4b49d6b199775fd2d2927768abdc8f50"},
@@ -865,78 +867,92 @@ six = [
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
 ]
 smmap = [
-    {file = "smmap-3.0.4-py2.py3-none-any.whl", hash = "sha256:54c44c197c819d5ef1991799a7e30b662d1e520f2ac75c9efbeb54a742214cf4"},
-    {file = "smmap-3.0.4.tar.gz", hash = "sha256:9c98bbd1f9786d22f14b3d4126894d56befb835ec90cef151af566c7e19b5d24"},
+    {file = "smmap-3.0.5-py2.py3-none-any.whl", hash = "sha256:7bfcf367828031dc893530a29cb35eb8c8f2d7c8f2d0989354d75d24c8573714"},
+    {file = "smmap-3.0.5.tar.gz", hash = "sha256:84c2751ef3072d4f6b2785ec7ee40244c6f45eb934d9e543e2c51f1bd3d54c50"},
 ]
 sniffio = [
-    {file = "sniffio-1.1.0-py3-none-any.whl", hash = "sha256:20ed6d5b46f8ae136d00b9dcb807615d83ed82ceea6b2058cecb696765246da5"},
-    {file = "sniffio-1.1.0.tar.gz", hash = "sha256:8e3810100f69fe0edd463d02ad407112542a11ffdc29f67db2bf3771afb87a21"},
+    {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},
+    {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
 ]
 stevedore = [
-    {file = "stevedore-3.2.0-py3-none-any.whl", hash = "sha256:c8f4f0ebbc394e52ddf49de8bcc3cf8ad2b4425ebac494106bbc5e3661ac7633"},
-    {file = "stevedore-3.2.0.tar.gz", hash = "sha256:38791aa5bed922b0a844513c5f9ed37774b68edc609e5ab8ab8d8fe0ce4315e5"},
+    {file = "stevedore-3.3.0-py3-none-any.whl", hash = "sha256:50d7b78fbaf0d04cd62411188fa7eedcb03eb7f4c4b37005615ceebe582aa82a"},
+    {file = "stevedore-3.3.0.tar.gz", hash = "sha256:3a5bbd0652bf552748871eaa73a4a8dc2899786bc497a2aa1fcb4dcdb0debeee"},
 ]
 typed-ast = [
-    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-win32.whl", hash = "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
-    {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
-    {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
-    {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
-    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
-    {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7703620125e4fb79b64aa52427ec192822e9f45d37d4b6625ab37ef403e1df70"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c9aadc4924d4b5799112837b226160428524a9a45f830e0d0f184b19e4090487"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:9ec45db0c766f196ae629e509f059ff05fc3148f9ffd28f3cfe75d4afb485412"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win32.whl", hash = "sha256:85f95aa97a35bdb2f2f7d10ec5bbdac0aeb9dafdaf88e17492da0504de2e6400"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win_amd64.whl", hash = "sha256:9044ef2df88d7f33692ae3f18d3be63dec69c4fb1b5a4a9ac950f9b4ba571606"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c1c876fd795b36126f773db9cbb393f19808edd2637e00fd6caba0e25f2c7b64"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5dcfc2e264bd8a1db8b11a892bd1647154ce03eeba94b461effe68790d8b8e07"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8db0e856712f79c45956da0c9a40ca4246abc3485ae0d7ecc86a20f5e4c09abc"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d003156bb6a59cda9050e983441b7fa2487f7800d76bdc065566b7d728b4581a"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win32.whl", hash = "sha256:4c790331247081ea7c632a76d5b2a265e6d325ecd3179d06e9cf8d46d90dd151"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win_amd64.whl", hash = "sha256:d175297e9533d8d37437abc14e8a83cbc68af93cc9c1c59c2c292ec59a0697a3"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf54cfa843f297991b7388c281cb3855d911137223c6b6d2dd82a47ae5125a41"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b4fcdcfa302538f70929eb7b392f536a237cbe2ed9cba88e3bf5027b39f5f77f"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:987f15737aba2ab5f3928c617ccf1ce412e2e321c77ab16ca5a293e7bbffd581"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:37f48d46d733d57cc70fd5f30572d11ab8ed92da6e6b28e024e4a3edfb456e37"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:36d829b31ab67d6fcb30e185ec996e1f72b892255a745d3a82138c97d21ed1cd"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:8368f83e93c7156ccd40e49a783a6a6850ca25b556c0fa0240ed0f659d2fe496"},
+    {file = "typed_ast-1.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:963c80b583b0661918718b095e02303d8078950b26cc00b5e5ea9ababe0de1fc"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:84aa6223d71012c68d577c83f4e7db50d11d6b1399a9c779046d75e24bed74ea"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a38878a223bdd37c9709d07cd357bb79f4c760b29210e14ad0fb395294583787"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win32.whl", hash = "sha256:a2c927c49f2029291fbabd673d51a2180038f8cd5a5b2f290f78c4516be48be2"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:c0c74e5579af4b977c8b932f40a5464764b2f86681327410aa028a22d2f54937"},
+    {file = "typed_ast-1.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:07d49388d5bf7e863f7fa2f124b1b1d89d8aa0e2f7812faff0a5658c01c59aa1"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:240296b27397e4e37874abb1df2a608a92df85cf3e2a04d0d4d61055c8305ba6"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:14bf1522cdee369e8f5581238edac09150c765ec1cb33615855889cf33dcb92d"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win32.whl", hash = "sha256:cc7b98bf58167b7f2db91a4327da24fb93368838eb84a44c472283778fc2446b"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:7147e2a76c75f0f64c4319886e7639e490fee87c9d25cb1d4faef1d8cf83a440"},
+    {file = "typed_ast-1.4.2.tar.gz", hash = "sha256:9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.7.4.2-py2-none-any.whl", hash = "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"},
-    {file = "typing_extensions-3.7.4.2-py3-none-any.whl", hash = "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5"},
-    {file = "typing_extensions-3.7.4.2.tar.gz", hash = "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"},
+    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
+    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
+    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
 ujson = [
-    {file = "ujson-3.1.0-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:585329c16eeb0992308545c7a05eee76c7f1c2042b08317aac64fef1e71e71a9"},
-    {file = "ujson-3.1.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:d40d53aa679994624960b1c40bc451c5d9e3a0779f6a04146b417e220ce8f7d4"},
-    {file = "ujson-3.1.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b794a2ddba049daa1fe0f28c4652b54d0d06580e7d3bcae87b4c000fb242654f"},
-    {file = "ujson-3.1.0-cp35-cp35m-win_amd64.whl", hash = "sha256:0789837e7156e07890f2461ec1d9dc2ea4ef7c76fd36e46955d811485daf83b9"},
-    {file = "ujson-3.1.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:f6e229fa9b7d8586f894d18a003703fea4620ff8e6d39c11499755ecec5b43fc"},
-    {file = "ujson-3.1.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:ebe1bc9536b93c697f042b6c39ed602ad7edd5ef139eb167d9c8e36594b24546"},
-    {file = "ujson-3.1.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6a2fac9892996c3a46bd3fd8bbf739f19f85fc7ec9cdc11b014f76267c3ee76d"},
-    {file = "ujson-3.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:083778f4e64f90b4468e73e0baafcde0ab83bff85315d28a5b1287a3f5909e7f"},
-    {file = "ujson-3.1.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:d3f28f64b33609be20f985baa72d43ccfdf87e50d47ca2791d26b9c2f348a35b"},
-    {file = "ujson-3.1.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3a049acf176dacbb79ee00b13a78fc2524c35c69400e34aa5f6ff0fc3fdbb1f0"},
-    {file = "ujson-3.1.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:c2be0d511e5dc302f190e510544c4d5fbbb4396632abe33b66e28dad26ea4325"},
-    {file = "ujson-3.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:7e7cdd8a42428cd2716cfe0a506e57168c6a02b8032478209cb4a8a12b8c2c4e"},
-    {file = "ujson-3.1.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:a8194b778adf38ad679c62e2bb6cf71972ae91102e611e4bb31f625be6fb366a"},
-    {file = "ujson-3.1.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:0184ed23618ce3d793aaf9f5b3dd456cf719b930d3936fb39000589ed0bd2811"},
-    {file = "ujson-3.1.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8032ca897cfce113cb9ca7f07ff4c750afe18c605eeed2e09cf9b882c99fc76b"},
-    {file = "ujson-3.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:bf30ac68d8b2aed665589cfd3608e43d8cd6cb74cd5a9379ab9af9861c33a8be"},
-    {file = "ujson-3.1.0.tar.gz", hash = "sha256:00bda1de275ed6fe81817902189c75dfd156b4fa29b44dc1f4620775d2f50cf7"},
+    {file = "ujson-4.0.2-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:e390df0dcc7897ffb98e17eae1f4c442c39c91814c298ad84d935a3c5c7a32fa"},
+    {file = "ujson-4.0.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:84b1dca0d53b0a8d58835f72ea2894e4d6cf7a5dd8f520ab4cbd698c81e49737"},
+    {file = "ujson-4.0.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:91396a585ba51f84dc71c8da60cdc86de6b60ba0272c389b6482020a1fac9394"},
+    {file = "ujson-4.0.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:eb6b25a7670c7537a5998e695fa62ff13c7f9c33faf82927adf4daa460d5f62e"},
+    {file = "ujson-4.0.2-cp36-cp36m-win_amd64.whl", hash = "sha256:f8aded54c2bc554ce20b397f72101737dd61ee7b81c771684a7dd7805e6cca0c"},
+    {file = "ujson-4.0.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:30962467c36ff6de6161d784cd2a6aac1097f0128b522d6e9291678e34fb2b47"},
+    {file = "ujson-4.0.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:fc51e545d65689c398161f07fd405104956ec27f22453de85898fa088b2cd4bb"},
+    {file = "ujson-4.0.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e6e90330670c78e727d6637bb5a215d3e093d8e3570d439fd4922942f88da361"},
+    {file = "ujson-4.0.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:5e1636b94c7f1f59a8ead4c8a7bab1b12cc52d4c21ababa295ffec56b445fd2a"},
+    {file = "ujson-4.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:e2cadeb0ddc98e3963bea266cc5b884e5d77d73adf807f0bda9eca64d1c509d5"},
+    {file = "ujson-4.0.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:a214ba5a21dad71a43c0f5aef917cd56a2d70bc974d845be211c66b6742a471c"},
+    {file = "ujson-4.0.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:0190d26c0e990c17ad072ec8593647218fe1c675d11089cd3d1440175b568967"},
+    {file = "ujson-4.0.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:f273a875c0b42c2a019c337631bc1907f6fdfbc84210cc0d1fff0e2019bbfaec"},
+    {file = "ujson-4.0.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:d3a87888c40b5bfcf69b4030427cd666893e826e82cc8608d1ba8b4b5e04ea99"},
+    {file = "ujson-4.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:7333e8bc45ea28c74ae26157eacaed5e5629dbada32e0103c23eb368f93af108"},
+    {file = "ujson-4.0.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b3a6dcc660220539aa718bcc9dbd6dedf2a01d19c875d1033f028f212e36d6bb"},
+    {file = "ujson-4.0.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:0ea07fe57f9157118ca689e7f6db72759395b99121c0ff038d2e38649c626fb1"},
+    {file = "ujson-4.0.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:4d6d061563470cac889c0a9fd367013a5dbd8efc36ad01ab3e67a57e56cad720"},
+    {file = "ujson-4.0.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b5c70704962cf93ec6ea3271a47d952b75ae1980d6c56b8496cec2a722075939"},
+    {file = "ujson-4.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:aad6d92f4d71e37ea70e966500f1951ecd065edca3a70d3861b37b176dd6702c"},
+    {file = "ujson-4.0.2.tar.gz", hash = "sha256:c615a9e9e378a7383b756b7e7a73c38b22aeb8967a8bfbffd4741f7ffd043c4d"},
 ]
 urllib3 = [
-    {file = "urllib3-1.25.10-py2.py3-none-any.whl", hash = "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"},
-    {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
+    {file = "urllib3-1.25.11-py2.py3-none-any.whl", hash = "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"},
+    {file = "urllib3-1.25.11.tar.gz", hash = "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2"},
 ]
 uvloop = [
-    {file = "uvloop-0.14.0-cp35-cp35m-macosx_10_11_x86_64.whl", hash = "sha256:08b109f0213af392150e2fe6f81d33261bb5ce968a288eb698aad4f46eb711bd"},
-    {file = "uvloop-0.14.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:4544dcf77d74f3a84f03dd6278174575c44c67d7165d4c42c71db3fdc3860726"},
-    {file = "uvloop-0.14.0-cp36-cp36m-macosx_10_11_x86_64.whl", hash = "sha256:b4f591aa4b3fa7f32fb51e2ee9fea1b495eb75b0b3c8d0ca52514ad675ae63f7"},
-    {file = "uvloop-0.14.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f07909cd9fc08c52d294b1570bba92186181ca01fe3dc9ffba68955273dd7362"},
-    {file = "uvloop-0.14.0-cp37-cp37m-macosx_10_11_x86_64.whl", hash = "sha256:afd5513c0ae414ec71d24f6f123614a80f3d27ca655a4fcf6cabe50994cc1891"},
-    {file = "uvloop-0.14.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e7514d7a48c063226b7d06617cbb12a14278d4323a065a8d46a7962686ce2e95"},
-    {file = "uvloop-0.14.0-cp38-cp38-macosx_10_11_x86_64.whl", hash = "sha256:bcac356d62edd330080aed082e78d4b580ff260a677508718f88016333e2c9c5"},
-    {file = "uvloop-0.14.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:4315d2ec3ca393dd5bc0b0089d23101276778c304d42faff5dc4579cb6caef09"},
-    {file = "uvloop-0.14.0.tar.gz", hash = "sha256:123ac9c0c7dd71464f58f1b4ee0bbd81285d96cdda8bc3519281b8973e3a461e"},
+    {file = "uvloop-0.15.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:19fa1d56c91341318ac5d417e7b61c56e9a41183946cc70c411341173de02c69"},
+    {file = "uvloop-0.15.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e5e5f855c9bf483ee6cd1eb9a179b740de80cb0ae2988e3fa22309b78e2ea0e7"},
+    {file = "uvloop-0.15.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:42eda9f525a208fbc4f7cecd00fa15c57cc57646c76632b3ba2fe005004f051d"},
+    {file = "uvloop-0.15.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:90e56f17755e41b425ad19a08c41dc358fa7bf1226c0f8e54d4d02d556f7af7c"},
+    {file = "uvloop-0.15.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:7ae39b11a5f4cec1432d706c21ecc62f9e04d116883178b09671aa29c46f7a47"},
+    {file = "uvloop-0.15.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:b45218c99795803fb8bdbc9435ff7f54e3a591b44cd4c121b02fa83affb61c7c"},
+    {file = "uvloop-0.15.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:114543c84e95df1b4ff546e6e3a27521580466a30127f12172a3278172ad68bc"},
+    {file = "uvloop-0.15.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:44cac8575bf168601424302045234d74e3561fbdbac39b2b54cc1d1d00b70760"},
+    {file = "uvloop-0.15.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:6de130d0cb78985a5d080e323b86c5ecaf3af82f4890492c05981707852f983c"},
+    {file = "uvloop-0.15.2.tar.gz", hash = "sha256:2bb0624a8a70834e54dde8feed62ed63b50bad7a1265c40d6403a2ac447bce01"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
@@ -967,6 +983,6 @@ websockets = [
     {file = "websockets-8.1.tar.gz", hash = "sha256:5c65d2da8c6bce0fca2528f69f44b2f977e06954c8512a952222cea50dad430f"},
 ]
 zipp = [
-    {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},
-    {file = "zipp-3.1.0.tar.gz", hash = "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"},
+    {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},
+    {file = "zipp-3.4.0.tar.gz", hash = "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ flake8 = "^3.8.3"
 coverage = "^5.1"
 pytest = "^5.4.3"
 pytest-cov = "^2.10.0"
-responses = "^0.10.15"
+responses = "^0.12.1"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/scripts/build-integration-test-images.sh
+++ b/scripts/build-integration-test-images.sh
@@ -1,0 +1,3 @@
+cd tests/integration/docker
+docker-compose build
+cd ../../..

--- a/scripts/run-dev-server.sh
+++ b/scripts/run-dev-server.sh
@@ -1,0 +1,3 @@
+cd tests/integration/docker
+docker-compose up
+cd ../../..

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -43,13 +43,3 @@ class AuthError(ResponseError):
             # Fall back to the full response body
             msg = resp_text
         super().__init__(code=-32001, message=msg)
-
-
-class InvalidParamsError(ResponseError):
-
-    def __init__(self, params, message):
-        super().__init__(code=-32602, message='Invalid params')
-        self.data = {
-            'params': params,
-            'message': message
-        }

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -43,3 +43,13 @@ class AuthError(ResponseError):
             # Fall back to the full response body
             msg = resp_text
         super().__init__(code=-32001, message=msg)
+
+
+class InvalidParamsError(ResponseError):
+
+    def __init__(self, params, message):
+        super().__init__(code=-32602, message='Invalid params')
+        self.data = {
+            'params': params,
+            'message': message
+        }

--- a/src/search1_conversion/convert_params.py
+++ b/src/search1_conversion/convert_params.py
@@ -210,8 +210,8 @@ def _get_search_params(params):
         'size': pagination.get('count', 20),
         'from': pagination.get('start', 0),
         'sort': sort,
-        'public_only': not with_private and with_public,
-        'private_only': not with_public and with_private,
+        'only_public': not with_private and with_public,
+        'only_private': not with_public and with_private,
         'track_total_hits': True
     }
     if 'GenomeFeature' in object_types:

--- a/src/search1_conversion/convert_params.py
+++ b/src/search1_conversion/convert_params.py
@@ -37,6 +37,7 @@ from src.utils.config import config
 from src.utils.obj_utils import get_any
 from src.exceptions import ResponseError
 
+
 # Unversioned feature index name/alias, (eg "genome_features")
 _FEATURES_UNVERSIONED = config['global']['genome_features_current_index_name']
 # Versioned feature index name (eg "genome_features_2")
@@ -202,16 +203,37 @@ def _get_search_params(params):
         sort.append({prop: {'order': order}})
     pagination = params.get('pagination', {})
     access_filter = params.get('access_filter', {})
-    with_private = bool(access_filter.get('with_private'))
-    with_public = bool(access_filter.get('with_public'))
+    with_private = access_filter.get('with_private')
+    with_public = access_filter.get('with_public')
+
+    if with_private is None and with_public is None:
+        only_public = False
+        only_private = False
+    else:
+        with_private = bool(with_private)
+        with_public = bool(with_public)
+        if with_private:
+            if with_public:
+                only_public = False
+                only_private = False
+            else:
+                only_public = False
+                only_private = True
+        elif with_public:
+            only_public = True
+            only_private = False
+        else:
+            # Error condition
+            raise ResponseError(code=-32602, message='May not specify no private data and no public data')
+
     # Get excluded index names (handles `exclude_subobjects`)
     search_params = {
         'query': query,
         'size': pagination.get('count', 20),
         'from': pagination.get('start', 0),
         'sort': sort,
-        'only_public': not with_private and with_public,
-        'only_private': not with_public and with_private,
+        'only_public': only_public,
+        'only_private': only_private,
         'track_total_hits': True
     }
     if 'GenomeFeature' in object_types:

--- a/src/utils/workspace.py
+++ b/src/utils/workspace.py
@@ -9,7 +9,7 @@ from src.utils.config import config
 from src.exceptions import AuthError
 
 
-def ws_auth(auth_token, public_only=False, private_only=False):
+def ws_auth(auth_token, only_public=False, only_private=False):
     """
     Get a list of workspace IDs that the given username is allowed to access in
     the workspace.
@@ -21,9 +21,9 @@ def ws_auth(auth_token, public_only=False, private_only=False):
         'perm': 'r'
     }
 
-    if public_only:
+    if only_public:
         params['onlyGlobal'] = 1
-    elif private_only:
+    elif only_private:
         params['excludeGlobal'] = 1
     else:
         params['excludeGlobal'] = 0

--- a/src/utils/workspace.py
+++ b/src/utils/workspace.py
@@ -22,10 +22,15 @@ def ws_auth(auth_token, only_public=False, only_private=False):
     }
 
     if only_public:
+        if only_private:
+            raise Exception('Only one of "only_public" or "only_private" may be set')
         params['onlyGlobal'] = 1
+        params['excludeGlobal'] = 0
     elif only_private:
+        params['onlyGlobal'] = 0
         params['excludeGlobal'] = 1
     else:
+        params['onlyGlobal'] = 0
         params['excludeGlobal'] = 0
 
     result = _req('list_workspace_ids', params, auth_token)

--- a/tests/helpers/common.py
+++ b/tests/helpers/common.py
@@ -30,6 +30,16 @@ def assert_jsonrpc20_result(actual, expected):
     return result
 
 
+def assert_jsonrpc20_error(actual, expected):
+    assert actual['jsonrpc'] == '2.0'
+    assert actual['id'] == expected['id']
+    assert 'result' not in actual
+    assert 'error' in actual
+    error = actual['error']
+    assert isinstance(error, dict)
+    return error
+
+
 def equal(d1, d2, path=[]):
     if isinstance(d1, dict):
         if isinstance(d2, dict):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,11 +6,16 @@ from tests.helpers.integration_setup import (
     stop_service
 )
 
-APP_URL = os.environ.get("APP_URL", 'http://localhost:5000')
+
+DEFAULT_APP_URL = 'http://localhost:5000'
+
+APP_URL = os.environ.get("APP_URL", DEFAULT_APP_URL)
 
 
 @pytest.fixture(scope="session")
 def service():
-    start_service(APP_URL)
+    if APP_URL == DEFAULT_APP_URL:
+        start_service(APP_URL)
     yield {'app_url': APP_URL}
-    stop_service()
+    if APP_URL == DEFAULT_APP_URL:
+        stop_service()

--- a/tests/integration/data/legacy/case-03-request.json
+++ b/tests/integration/data/legacy/case-03-request.json
@@ -1,0 +1,38 @@
+{
+	"params": [{
+		"match_filter": {
+			"full_text_in_all": "coli",
+			"exclude_subobjects": 1,
+			"source_tags": ["refdata", "noindex"],
+			"source_tags_blacklist": 1
+		},
+		"pagination": {
+			"start": 0,
+			"count": 20
+		},
+		"post_processing": {
+			"ids_only": 0,
+			"skip_info": 0,
+			"skip_keys": 0,
+			"skip_data": 0,
+			"include_highlight": 1,
+			"add_narrative_info": 1
+		},
+		"access_filter": {
+			"with_private": 1,
+			"with_public": 1
+		},
+		"sorting_rules": [{
+			"is_object_property": 0,
+			"property": "access_group_id",
+			"ascending": 0
+		}, {
+			"is_object_property": 0,
+			"property": "type",
+			"ascending": 1
+		}]
+	}],
+	"method": "KBaseSearchEngine.search_objects",
+	"version": "1.1",
+	"id": "12573638302160872"
+}

--- a/tests/integration/data/legacy/case-03-response.json
+++ b/tests/integration/data/legacy/case-03-response.json
@@ -1,0 +1,1017 @@
+{
+	"id": "12573638302160872",
+	"jsonrpc": "2.0",
+	"result": [{
+		"pagination": {
+			"start": 0,
+			"count": 20
+		},
+		"sorting_rules": [{
+			"is_object_property": 0,
+			"property": "access_group_id",
+			"ascending": 0
+		}, {
+			"is_object_property": 0,
+			"property": "type",
+			"ascending": 1
+		}],
+		"total": 9,
+		"search_time": 864,
+		"objects": [{
+			"object_name": "Narrative.1600793596676",
+			"access_group": 54113,
+			"obj_id": 1,
+			"version": 10,
+			"timestamp": 1601339675573,
+			"type": "Narrative",
+			"creator": "eapearson",
+			"data": {
+				"narrative_title": "Fungi",
+				"is_narratorial": false,
+				"data_objects": [{
+					"name": "Candida_arabinofermentans",
+					"obj_type": "KBaseGenomes.Genome-15.1"
+				}, {
+					"name": "Candida_tenuis_ATCC_10573",
+					"obj_type": "KBaseGenomes.Genome-15.1"
+				}, {
+					"name": "Aspergillus_niger",
+					"obj_type": "KBaseGenomes.Genome-15.1"
+				}],
+				"owner": "eapearson",
+				"modified_at": 1601339675000,
+				"cells": [{
+					"desc": "Fungi\nhttps://www.sciencedirect.com/science/article/pii/S1808869415305243#tbl1\nMICROORGANISM   No  %\nBACTERIA \nStaphylococcus aureus   65  24,34\nStreptococcus pyogenes  13  4,87\nStreptococcus pneumoniae    16  5,99\nPseudomonas aeroginosa  32  11,99\nKlebsiella pneumoniae   16  5,99\nKlebsiella oxytoca  7   2,62\nKlebsiella ozanae   4   1,50\nEnterobacter aerogenes  11  4,12\nEscherichia coli    6   2,25\nProteus mirabilis   6   2,25\nProteus vulgaris    2   0,75\nMoraxella catarrhalis   4   1,50\nTOTAL AEROBIC-FACULTATIF BACTERIA   182 68,16\nBacteroides fragilis    2   0,75\nPeptostreptococcus sp.  1   0,37\nTOTAL ANAEROBIC BACTERIA    3   1,12\nTOTAL BACTERIA FUNGI    185 69,29\nCandida sp. 33  12,36\nAspergillus flavus  13  4,87\nAspergillus fumigatus   4   1,50\nAspergillus niger   9   3,37\nMucor sp.   10  3,75\nPenicillium sp. 12  4,49\nTOTAL FUNGI 82  30,71\nTOTAL ISOLATES  267 100\n",
+					"cell_type": "markdown"
+				}],
+				"total_cells": 1,
+				"static_narrative_saved": null,
+				"static_narrative_ref": null,
+				"shared_users": ["eapearson"],
+				"creation_date": "2020-09-22T16:53:16+0000",
+				"is_public": false,
+				"copied": null,
+				"tags": ["narrative"],
+				"obj_type_version": "4.0",
+				"obj_type_module": "KBaseNarrative"
+			},
+			"guid": "WS:54113/1/1",
+			"kbase_id": "54113/1/1",
+			"index_name": "narrative_2",
+			"type_ver": 0,
+			"highlight": {
+				"cells.desc": ["Klebsiella oxytoca  7   2,62\nKlebsiella ozanae   4   1,50\nEnterobacter aerogenes  11  4,12\nEscherichia <em>coli</em>"]
+			}
+		}, {
+			"object_name": "Narrative.1594758723895",
+			"access_group": 52489,
+			"obj_id": 1,
+			"version": 23,
+			"timestamp": 1609804811154,
+			"type": "Narrative",
+			"creator": "eapearson",
+			"data": {
+				"narrative_title": "Taxonomy Landing Page Testing",
+				"is_narratorial": false,
+				"data_objects": [],
+				"owner": "eapearson",
+				"modified_at": 1609804811000,
+				"cells": [{
+					"desc": "Taxonomy Landing Page Testing\nA Narrative full of fun stuff about testing the taxonomy landing page\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "URL Format\nThe following endpoints are supported\ntaxonomy/taxon/NAMESPACE/ID/[TIMESTAMP]\nTaxon landing page for viewing taxon ID in namespace NAMESPACE with optional TIMESTAMP.\nSee examples below.\ntaxonomy/about\nplaceholder\ntaxonomy/help\nplaceholder\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "NCBI\nnamespace: ncbi_taxonomy\nExample for Escherichia coli:\nhttps://ci.kbase.us#taxonomy/taxon/ncbi_taxonomy/562\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "GTDB\nnamespace: gtdb\nExample for Escherichia coli:\nhttps://ci.kbase.us#taxonomy/taxon/gtdb/GBGCA900481195.1\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "RDP\nnamespace: rdb_taxonomy\nExample for Escherichia coli; PK3; X80731:\nhttps://ci.kbase.us#taxonomy/taxon/rdp_taxonomy/S000000986\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "SILVA\nnamespace: silva_taxonomy\nExample for Escherichia coli; PK3; X80731:\nhttps://ci.kbase.us#taxonomy/taxon/silva_taxonomy/HG710171.1.771\n",
+					"cell_type": "markdown"
+				}],
+				"total_cells": 6,
+				"static_narrative_saved": null,
+				"static_narrative_ref": null,
+				"shared_users": ["eapearson", "scanon", "psdehal"],
+				"creation_date": "2020-07-14T20:32:04+0000",
+				"is_public": true,
+				"copied": null,
+				"tags": ["narrative"],
+				"obj_type_version": "4.0",
+				"obj_type_module": "KBaseNarrative"
+			},
+			"guid": "WS:52489/1/1",
+			"kbase_id": "52489/1/1",
+			"index_name": "narrative_2",
+			"type_ver": 0,
+			"highlight": {
+				"cells.desc": ["NCBI\nnamespace: ncbi_taxonomy\nExample for Escherichia <em>coli</em>:\nhttps://ci.kbase.us#taxonomy/taxon/ncbi_taxonomy", "GTDB\nnamespace: gtdb\nExample for Escherichia <em>coli</em>:\nhttps://ci.kbase.us#taxonomy/taxon/gtdb/GBGCA900481195.1", "RDP\nnamespace: rdb_taxonomy\nExample for Escherichia <em>coli</em>; PK3; X80731:\nhttps://ci.kbase.us#taxonomy/taxon", "SILVA\nnamespace: silva_taxonomy\nExample for Escherichia <em>coli</em>; PK3; X80731:\nhttps://ci.kbase.us#taxonomy"]
+			}
+		}, {
+			"object_name": "Narrative.1585596681448",
+			"access_group": 48753,
+			"obj_id": 1,
+			"version": 7,
+			"timestamp": 1586539905964,
+			"type": "Narrative",
+			"creator": "eapearson",
+			"data": {
+				"narrative_title": "RE landing page sample links",
+				"is_temporary": false,
+				"is_narratorial": false,
+				"data_objects": [{
+					"name": "Abiotrophia_defectiva_ATCC_49176",
+					"obj_type": "KBaseGenomes.Genome-17.0"
+				}],
+				"owner": "eapearson",
+				"modified_at": 1586539906000,
+				"cells": [{
+					"desc": "Relation Engine Landing Pages\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Ontology Landing Pages\nStart at the root, and explore!\nbiological process - https://ci.kbase.us/#review/go_ontology/GO:0008150\nbiological process - https://ci.kbase.us/#review/go_ontology/GO:0008150\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Taxonomy Landing Pages\nThe ubiquitous E. coli...\nNCBI:\nhttps://ci.kbase.us/#review/ncbi_taxonomy/562\nGTDB:\nhttps://ci.kbase.us#review/gtdb/GBGCA900481195.1\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Relation engine landing page urls\nA url to the relation engine landing page looks like:\n\nhttps://ci.kbase.us#review/namespace/id[/ts]\n\nwhere\n\nreview is the name of the relation engine landing page plugin endpoint; this is short for \"relation engine view\"\nnamespace is the collection to be accessed; e.g. ncbi_taxonomy, gtdb, go_ontology.\nid is the identifier for the specific item to be viewed; the form of the id depends on the collection,e.g. 562 is E. coli in the ncbi taxonomy, GO:0008150 is the id for \"biological process\" in the go ontology.\nts is an optional timestamp associated with the specific instance of the item; items within a collection are stamped with an time range which defines when the item is valid; this is used to manage collection updates over time. If omitted, the most recent version of the item is selected\n\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Taxonomy API\nThe kb sdk module taxonomy_re_api serves as the taxonomy api.\nIn order to test calls against it, you'll first need to get the url:\njson\n{\n    \"version\": \"1.1\",\n    \"method\": \"ServiceWizard.get_service_status\",\n    \"id\": \"9360468998301\",\n    \"params\": [{\n        \"module_name\": \"taxonomy_re_api\",\n        \"version\": \"dev\"\n    }]\n}\n\nwill give you something like:\njson\n{\n    \"version\": \"1.1\",\n    \"result\": [\n        {\n            \"git_commit_hash\": \"5a120b167a19b7b5fb87a11c7c35f704a225c156\",\n            \"status\": \"active\",\n            \"version\": \"3.4.0\",\n            \"hash\": \"5a120b167a19b7b5fb87a11c7c35f704a225c156\",\n            \"release_tags\": [\n                \"dev\"\n            ],\n            \"url\": \"https://ci.kbase.us:443/dynserv/5a120b167a19b7b5fb87a11c7c35f704a225c156.taxonomy-re-api\",\n            \"module_name\": \"taxonomy_re_api\",\n            \"health\": \"healthy\",\n            \"up\": 1\n        }\n    ],\n    \"id\": \"9360468998301\"\n}\n\nArmed with the service url, it is handy to be able to find critters to explore:\nThe taxonomy_re_api.search_taxa method can be used with a free-form text search to find taxonomic entities:\njson\n{\n    \"params\": [{\n        \"ns\": \"gtdb\",\n        \"search_text\": \"coli\"\n    }],\n    \"method\": \"taxonomy_re_api.search_taxa\",\n    \"version\": \"1.1\",\n    \"id\": \"3658889363010196\"\n}\n\nreturns \njson\n{\n    \"result\": [\n        {\n            \"stats\": {\n                \"executionTime\": 0.08076357841491699,\n                \"filtered\": 0,\n                \"httpRequests\": 0,\n                \"peakMemoryUsage\": 1563242,\n                \"scannedFull\": 0,\n                \"scannedIndex\": 3147,\n                \"writesExecuted\": 0,\n                \"writesIgnored\": 0\n            },\n            \"total_count\": 3147,\n            \"results\": [\n                {\n                    \"_id\": \"gtdb_taxon/GB_GCA_900481195.1_r89\",\n                    \"_key\": \"GB_GCA_900481195.1_r89\",\n                    \"_rev\": \"_ZclM1Oa--e\",\n                    \"created\": 0,\n                    \"expired\": 9007199254740991,\n                    \"first_version\": \"r89\",\n                    \"id\": \"GB_GCA_900481195.1\",\n                    \"last_version\": \"r89\",\n                    \"name\": \"Escherichia coli\",\n                    \"rank\": \"genome\",\n                    \"release_created\": 0,\n                    \"release_expired\": 9007199254740991\n                },\n                {\n                    \"_id\": \"gtdb_taxon/RS_GCF_002548945.1_r89\",\n                    \"_key\": \"RS_GCF_002548945.1_r89\",\n                    \"_rev\": \"_ZclM1Oa--M\",\n                    \"created\": 0,\n                    \"expired\": 9007199254740991,\n                    \"first_version\": \"r89\",\n                    \"id\": \"RS_GCF_002548945.1\",\n                    \"last_version\": \"r89\",\n                    \"name\": \"Escherichia coli\",\n                    \"rank\": \"genome\",\n                    \"release_created\": 0,\n                    \"release_expired\": 9007199254740991\n                },\n\nFrom here you can grab the id and make another call. The taxonomy api repo documents the api calls, which include:\n\nget_taxon\ngettaxonfromwsobj\ngetassociatedws_objects\nget_lineage\nget_children\nget_siblings\nsearch_species\nsearch_taxa\n\njson\n{\n    \"params\": [{\n        \"ns\": \"gtdb\",\n        \"id\": \"GB_GCA_900481195.1\"\n    }],\n    \"method\": \"taxonomy_re_api.get_lineage\",\n    \"version\": \"1.1\",\n    \"id\": \"3658889363010196\"\n}\n\n",
+					"cell_type": "markdown"
+				}],
+				"total_cells": 5,
+				"static_narrative_saved": null,
+				"static_narrative_ref": null,
+				"shared_users": ["eapearson", "scanon"],
+				"creation_date": "2020-03-30T19:31:21+0000",
+				"is_public": true,
+				"copied": null,
+				"tags": ["narrative"],
+				"obj_type_version": "4.0",
+				"obj_type_module": "KBaseNarrative"
+			},
+			"guid": "WS:48753/1/1",
+			"kbase_id": "48753/1/1",
+			"index_name": "narrative_2",
+			"type_ver": 0,
+			"highlight": {
+				"cells.desc": ["Taxonomy Landing Pages\nThe ubiquitous E. <em>coli</em>...", "identifier for the specific item to be viewed; the form of the id depends on the collection,e.g. 562 is E. <em>coli</em>", "search to find taxonomic entities:\njson\n{\n    \"params\": [{\n        \"ns\": \"gtdb\",\n        \"search_text\": \"<em>coli</em>", "GB_GCA_900481195.1\",\n                    \"last_version\": \"r89\",\n                    \"name\": \"Escherichia <em>coli</em>", "RS_GCF_002548945.1\",\n                    \"last_version\": \"r89\",\n                    \"name\": \"Escherichia <em>coli</em>"]
+			}
+		}, {
+			"object_name": "Narrative.1569012281066",
+			"access_group": 44150,
+			"obj_id": 1,
+			"version": 15,
+			"timestamp": 1582215852059,
+			"type": "Narrative",
+			"creator": "eapearson",
+			"data": {
+				"narrative_title": "Relation Engine (RE) Landing Page Demo",
+				"is_temporary": false,
+				"is_narratorial": false,
+				"data_objects": [{
+					"name": "Escherichia_coli_2",
+					"obj_type": "KBaseGenomes.Genome-12.3"
+				}, {
+					"name": "Pseudomonas_aeruginosa",
+					"obj_type": "KBaseGenomes.Genome-12.3"
+				}],
+				"owner": "eapearson",
+				"modified_at": 1582215852000,
+				"cells": [{
+					"desc": "This narrative provide links to ontology and taxonomy landing pages.\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Ontology Landing Page Examples\nThere is no object landing page support for re ontology yet, so we present some links to interesting ontology term landing pages:\nLinked Features\nThis one should have linked features:\nhatching behavior\n\nNote: There were linked features appearing a few days ago, but not now.\n\nLarge Graph\nneed an example\nMany children\nneed an example\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Taxonomy Examples\nObjects on the left don't have relations in place to their taxons, so the landing page shows an error message.\nThe examples from below use refdata objects because their relationships have been manually built.\nRelationships are being built in real time, although given the mis-assignments at present it is a bit difficult to trace. The E. coli in the data panel to is actually linked from the \"E. coli\" taxon landing page you can get to from the genome landing page cited below. You can get back to this narrative from that link as well!\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Genome Landing Page\n\nE. coli refdata\nThis link leads to a Genome landing page which shows the lineage widget rewritten to use the Relation Engine to:\n- get the taxon ref given the object ref\n- get the taxon for the taxon ref\n- get the lineage for the taxon ref\nThe lineage widget shows the existing lineage widget, which derives its data from the genome object itself (scientific name and lineage).\nClicking on the scientific name or any class in the lineage will open the associated taxonomy landing page.\nThe linked objects tab has 3 items.\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Genome Landing Page\n\nPseudomonas aeruginosa refdata\nThis link leads to a Genome landing page which shows the lineage widget rewritten to use the Relation Engine to:\n- get the taxon ref given the object ref\n- get the taxon for the taxon ref\n- get the lineage for the taxon ref\nThe lineage widget shows the existing lineage widget, which derives its data from the genome object itself (scientific name and lineage).\nClicking on the scientific name or any class in the lineage will open the associated taxonomy landing page.\nThe linked objects tab has 442 linked objects shows the scale better.\n",
+					"cell_type": "markdown"
+				}],
+				"total_cells": 5,
+				"static_narrative_saved": "1573231380073",
+				"static_narrative_ref": "/44150/14",
+				"shared_users": ["eapearson", "scanon"],
+				"creation_date": "2019-09-20T20:44:41+0000",
+				"is_public": true,
+				"copied": null,
+				"tags": ["narrative"],
+				"obj_type_version": "4.0",
+				"obj_type_module": "KBaseNarrative"
+			},
+			"guid": "WS:44150/1/1",
+			"kbase_id": "44150/1/1",
+			"index_name": "narrative_2",
+			"type_ver": 0,
+			"highlight": {
+				"cells.desc": ["The E. <em>coli</em> in the data panel to is actually linked from the \"E. <em>coli</em>\" taxon landing page you can get", "Genome Landing Page\n\nE. <em>coli</em> refdata\nThis link leads to a Genome landing page which shows the lineage"]
+			}
+		}, {
+			"object_name": "ecoli_2contigs_orig",
+			"access_group": 33192,
+			"obj_id": 36,
+			"version": 1,
+			"timestamp": 1574185738033,
+			"type": "Genome",
+			"creator": "jayrbolton",
+			"data": {
+				"genome_id": "ecoli_2contigs_orig",
+				"scientific_name": "Escherichia coli str. K-12 substr. MG1655",
+				"publication_titles": ["Direct Submission", "Direct Submission", "Direct Submission", "Direct Submission", "Direct Submission", "Direct Submission", "Escherichia coli K-12: a cooperatively developed annotation snapshot--2005", "Direct Submission", "Direct Submission", "Highly accurate genome sequences of Escherichia coli K-12 strains MG1655 and W3110", "Workshop on Annotation of Escherichia coli K-12", "The complete genome sequence of Escherichia coli K-12", "Escherichia coli K-12 MG1655 yqiK-rfaE intergenic region, genomic sequence correction", "ASAP: Escherichia coli K-12 strain MG1655 version m56", "A manual approach to accurate translation start site annotation: an E. coli K-12 case study", "Direct Submission", "Direct Submission", "A more accurate sequence comparison between genomes of Escherichia coli K12 W3110 and MG1655 strains"],
+				"publication_authors": ["Blattner,F.R. and Plunkett,G. III.", "Plunkett,G. III.", "Plunkett,G. III.", "Plunkett,G. III.", "Blattner,F.R. and Plunkett,G. III.", "Rudd,K.E.", "Riley,M., Abe,T., Arnaud,M.B., Berlyn,M.K., Blattner,F.R., Chaudhuri,R.R., Glasner,J.D., Horiuchi,T., Keseler,I.M., Kosuge,T., Mori,H., Perna,N.T., Plunkett,G. III, Rudd,K.E., Serres,M.H., Thomas,G.H., Thomson,N.R., Wishart,D. and Wanner,B.L.", "Blattner,F.R. and Plunkett,G. III.", "Blattner,F.R. and Plunkett,G. III.", "Hayashi,K., Morooka,N., Yamamoto,Y., Fujita,K., Isono,K., Choi,S., Ohtsubo,E., Baba,T., Wanner,B.L., Mori,H. and Horiuchi,T.", "Arnaud,M., Berlyn,M.K.B., Blattner,F.R., Galperin,M.Y., Glasner,J.D., Horiuchi,T., Kosuge,T., Mori,H., Perna,N.T., Plunkett,G. III, Riley,M., Rudd,K.E., Serres,M.H., Thomas,G.H. and Wanner,B.L.", "Blattner,F.R., Plunkett,G. III, Bloch,C.A., Perna,N.T., Burland,V., Riley,M., Collado-Vides,J., Glasner,J.D., Rode,C.K., Mayhew,G.F., Gregor,J., Davis,N.W., Kirkpatrick,H.A., Goeden,M.A., Rose,D.J., Mau,B. and Shao,Y.", "Perna,N.T.", "Glasner,J.D., Perna,N.T., Plunkett,G. III, Anderson,B.D., Bockhorst,J., Hu,J.C., Riley,M., Rudd,K.E. and Serres,M.H.", "Rudd,K.E.", "Rudd,K.E.", "Blattner,F.R. and Plunkett,G. III.", "Hayashi,K., Morooka,N., Mori,H. and Horiuchi,T."],
+				"size": 4641772,
+				"num_contigs": 2,
+				"genome_type": null,
+				"gc_content": 0.5079,
+				"taxonomy": "Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacterales; Enterobacteriaceae; Escherichia; Escherichia coli; Escherichia coli K-12",
+				"mean_contig_length": 2320886.0,
+				"external_origination_date": "08-Aug-2016",
+				"original_source_file_name": "GCF_000005845.2_ASM584v2_altered_genomic.gbff",
+				"cds_count": 4319,
+				"feature_count": 4319,
+				"mrna_count": 0,
+				"non_coding_feature_count": 773,
+				"assembly_ref": "45290:1:1",
+				"source_id": "NC_000913",
+				"feature_counts": {
+					"CDS": 4319,
+					"gene": 4498,
+					"misc_feature": 11,
+					"mobile_element": 49,
+					"ncRNA": 65,
+					"non_coding_features": 773,
+					"non_coding_genes": 179,
+					"protein_encoding_gene": 4319,
+					"rRNA": 22,
+					"rep_origin": 1,
+					"repeat_region": 355,
+					"tRNA": 89,
+					"tmRNA": 2
+				},
+				"source": "Genbank",
+				"warnings": [],
+				"shared_users": ["jayrbolton"],
+				"creation_date": "2020-09-08T21:00:43+0000",
+				"is_public": true,
+				"copied": "45290/2/1",
+				"tags": ["narrative"],
+				"obj_type_version": "17.0",
+				"obj_type_module": "KBaseGenomes"
+			},
+			"guid": "WS:33192/36/1",
+			"kbase_id": "33192/36/1",
+			"index_name": "genome_2",
+			"type_ver": 0,
+			"highlight": {
+				"publication_titles": ["Escherichia <em>coli</em> K-12: a cooperatively developed annotation snapshot--2005", "Highly accurate genome sequences of Escherichia <em>coli</em> K-12 strains MG1655 and W3110", "Workshop on Annotation of Escherichia <em>coli</em> K-12", "The complete genome sequence of Escherichia <em>coli</em> K-12", "ASAP: Escherichia <em>coli</em> K-12 strain MG1655 version m56"],
+				"scientific_name": ["Escherichia <em>coli</em> str. K-12 substr. MG1655"],
+				"taxonomy": ["Proteobacteria; Gammaproteobacteria; Enterobacterales; Enterobacteriaceae; Escherichia; Escherichia <em>coli</em>", "; Escherichia <em>coli</em> K-12"]
+			}
+		}, {
+			"object_name": "Narrative.1465364940970",
+			"access_group": 9004,
+			"obj_id": 64,
+			"version": 10,
+			"timestamp": 1469599902261,
+			"type": "Narrative",
+			"creator": "marcin",
+			"data": {
+				"narrative_title": "External_source_reference_genomes_for_testing",
+				"is_temporary": false,
+				"is_narratorial": false,
+				"data_objects": [{
+					"name": "Cyanidioschyzon_merolae.ASM9120v1.31_contigs",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "Cyanidioschyzon_merolae.ASM9120v1.31",
+					"obj_type": "KBaseGenomes.Genome-11.0"
+				}, {
+					"name": "Arabidopsis_thaliana.TAIR10.31_contigs",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "Arabidopsis_thaliana.TAIR10.31",
+					"obj_type": "KBaseGenomes.Genome-11.0"
+				}, {
+					"name": "GCF_000005845.2_ASM584v2_genomic_contigs",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "GCF_000005845.2_ASM584v2_genomic",
+					"obj_type": "KBaseGenomes.Genome-11.0"
+				}, {
+					"name": "GCF_000001735.3_TAIR10_rna_contigs",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "GCF_000001735.3_TAIR10_rna",
+					"obj_type": "KBaseGenomes.Genome-11.0"
+				}, {
+					"name": "GCF_000005845.2_ASM584v2_genomic_GA_assembly",
+					"obj_type": "KBaseGenomeAnnotations.Assembly-4.1"
+				}, {
+					"name": "GCF_000005845.2_ASM584v2_genomic_GA",
+					"obj_type": "KBaseGenomeAnnotations.GenomeAnnotation-3.1"
+				}, {
+					"name": "GCF_000005845.2_ASM584v2_genomic_GA_assembly_contigset",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "GCF_000005845.2_ASM584v2_genomic_GA_genome",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "Cyanidioschyzon_merolae.ASM9120v1.31_GA_assembly",
+					"obj_type": "KBaseGenomeAnnotations.Assembly-4.1"
+				}, {
+					"name": "Cyanidioschyzon_merolae.ASM9120v1.31_GA",
+					"obj_type": "KBaseGenomeAnnotations.GenomeAnnotation-3.1"
+				}, {
+					"name": "Cyanidioschyzon_merolae.ASM9120v1.31_GA_assembly_contigset",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "GCF_000001735.3_TAIR10_genomic_GA_assembly",
+					"obj_type": "KBaseGenomeAnnotations.Assembly-4.1"
+				}, {
+					"name": "GCF_000001735.3_TAIR10_genomic_GA",
+					"obj_type": "KBaseGenomeAnnotations.GenomeAnnotation-3.1"
+				}, {
+					"name": "GCF_000001735.3_TAIR10_genomic_GA_assembly_contigset",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "GCF_000001735.3_TAIR10_genomic_GA_genome",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "Cyanidioschyzon_merolae.ASM9120v1.31_GA_contigset_legacy",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "Cyanidioschyzon_merolae.ASM9120v1.31_GA_genome_legacy",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "Cyanidioschyzon_merolae.ASM9120v1.31_GA_genome_legacy_model",
+					"obj_type": "KBaseFBA.FBAModel-13.0"
+				}, {
+					"name": "GCF_000001735.3_TAIR10_genomic_GA_contigset_legacy",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "GCF_000001735.3_TAIR10_genomic_GA_genome_legacy",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "GCF_000005845.2_ASM584v2_genomic_GA_contigset_legacy",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "GCF_000005845.2_ASM584v2_genomic_GA_genome_legacy",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "ecoli_annotate",
+					"obj_type": "KBaseGenomes.Genome-12.0"
+				}, {
+					"name": "Ecoli_R7_reads",
+					"obj_type": "KBaseAssembly.SingleEndLibrary-2.0"
+				}],
+				"owner": "marcin",
+				"modified_at": 1469599902000,
+				"cells": [{
+					"desc": "",
+					"cell_type": "code_cell"
+				}, {
+					"desc": "BLASTp prot-prot Search",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Assemble Contigs from Reads",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "BLASTn nuc-nuc Search",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "from biokbase.narrative.jobs.jobmanager import JobManager\nJobManager().get_job('57984a51e4b0222db3be1df5')",
+					"cell_type": "code_cell"
+				}, {
+					"desc": "Align Whole Genomes with Mugsy",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Annotate Genome with InterproScan",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "from biokbase.narrative.widgetmanager import WidgetManager\nWidgetManager().show_output_widget(\n    \"kbaseNarrativeDataCell\",\n    {\"info\": {\"id\":63,\"name\":\"GCF_000005845.2_ASM584v2_genomic_GA_genome_legacy\",\"type\":\"KBaseGenomes.Genome-8.0\",\"save_date\":\"2016-07-25T19:28:17+0000\",\"version\":1,\"saved_by\":\"marcin\",\"ws_id\":9004,\"ws_name\":\"marcin:1469474890415\",\"chsum\":\"7f92a66bcd9d5822633cc79e324bc9db\",\"size\":12789016,\"meta\":{\"Source\":\"unknown_source\",\"Name\":\"Escherichia coli str. K-12 substr. MG1655\",\"Domain\":\"Bacteria\",\"GC content\":\"0.5079070985933456\",\"Number features\":\"9411\",\"MD5\":\"d41d8cd98f00b204e9800998ecf8427e\",\"Taxonomy\":\"cellular organisms;Bacteria;Proteobacteria;Gammaproteobacteria;Enterobacteriales;Enterobacteriaceae;Escherichia;Escherichia coli;Escherichia coli K-12\",\"Source ID\":\"NC_000913\",\"Number contigs\":\"1\",\"note\":\"Down-converted from a KBase GenomeAnnotation object. Methods using this type are being upgraded to use the Data API.\",\"Genetic code\":\"11\",\"Size\":\"4641652\"}}},\n    check_widget=False,\n    title=\"GCF_000005845.2_ASM584v2_genomic_GA_genome_legacy\",\n    type=\"viewer\",\n)",
+					"cell_type": "code_cell"
+				}, {
+					"desc": "Annotate Microbial Genome",
+					"cell_type": "kbase_app"
+				}],
+				"total_cells": 9,
+				"static_narrative_saved": null,
+				"static_narrative_ref": null,
+				"shared_users": ["marcin"],
+				"creation_date": "2016-07-25T19:28:18+0000",
+				"is_public": true,
+				"copied": null,
+				"tags": [],
+				"obj_type_version": "4.0",
+				"obj_type_module": "KBaseNarrative"
+			},
+			"guid": "WS:9004/64/1",
+			"kbase_id": "9004/64/1",
+			"index_name": "narrative_2",
+			"type_ver": 0,
+			"highlight": {
+				"cells.desc": ["7f92a66bcd9d5822633cc79e324bc9db\",\"size\":12789016,\"meta\":{\"Source\":\"unknown_source\",\"Name\":\"Escherichia <em>coli</em>", "Bacteria;Proteobacteria;Gammaproteobacteria;Enterobacteriales;Enterobacteriaceae;Escherichia;Escherichia <em>coli</em>", ";Escherichia <em>coli</em> K-12\",\"Source ID\":\"NC_000913\",\"Number contigs\":\"1\",\"note\":\"Down-converted from a KBase"]
+			}
+		}, {
+			"object_name": "Narrative.1466012171819",
+			"access_group": 7998,
+			"obj_id": 1,
+			"version": 640,
+			"timestamp": 1600897144545,
+			"type": "Narrative",
+			"creator": "scanon",
+			"data": {
+				"narrative_title": "HipMer Testing",
+				"is_narratorial": false,
+				"data_objects": [{
+					"name": "ecoli",
+					"obj_type": "KBaseAssembly.PairedEndLibrary-2.0"
+				}, {
+					"name": "output",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "ecoli-assemb",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "Set",
+					"obj_type": "KBaseSets.ReadsSet-1.0"
+				}, {
+					"name": "ecoli.contigs",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "short",
+					"obj_type": "KBaseAssembly.SingleEndLibrary-2.0"
+				}, {
+					"name": "long",
+					"obj_type": "KBaseAssembly.SingleEndLibrary-2.0"
+				}, {
+					"name": "hipmer.contigs",
+					"obj_type": "KBaseGenomeAnnotations.Assembly-6.0"
+				}, {
+					"name": "ecoli.contigs2",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "Ecoli-Test",
+					"obj_type": "KBaseFile.PairedEndLibrary-2.2"
+				}, {
+					"name": "chr14-longjump",
+					"obj_type": "KBaseFile.PairedEndLibrary-2.2"
+				}, {
+					"name": "chr14-shortjump",
+					"obj_type": "KBaseFile.PairedEndLibrary-2.2"
+				}, {
+					"name": "frags",
+					"obj_type": "KBaseFile.PairedEndLibrary-2.2"
+				}, {
+					"name": "ecoli.contig",
+					"obj_type": "KBaseGenomeAnnotations.Assembly-4.1"
+				}, {
+					"name": "chr14",
+					"obj_type": "KBaseGenomeAnnotations.Assembly-4.1"
+				}, {
+					"name": "ecoli-assembly",
+					"obj_type": "KBaseGenomeAnnotations.Assembly-4.1"
+				}, {
+					"name": "hipmer-condor.contigs",
+					"obj_type": "KBaseGenomeAnnotations.Assembly-6.0"
+				}, {
+					"name": "coli1",
+					"obj_type": "KBaseGenomeAnnotations.Assembly-6.0"
+				}, {
+					"name": "ecoli-hpc",
+					"obj_type": "KBaseGenomeAnnotations.Assembly-6.0"
+				}, {
+					"name": "small.interlaced_reads",
+					"obj_type": "KBaseFile.PairedEndLibrary-2.2"
+				}, {
+					"name": "mock2pct",
+					"obj_type": "KBaseFile.PairedEndLibrary-2.2"
+				}, {
+					"name": "mock2pct.250.bbqc.sampled",
+					"obj_type": "KBaseFile.PairedEndLibrary-2.2"
+				}],
+				"owner": "scanon",
+				"modified_at": 1600897144000,
+				"cells": [{
+					"desc": "Test of HipMer (Work-in-progress)\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Loading E Coli Data\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Load Paired-End Reads From Staging Area",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "kbaseReadsViewer",
+					"cell_type": "widget"
+				}, {
+					"desc": "from biokbase.narrative.jobs.appmanager import AppManager\nAppManager().run_app(\n    \"hipmer/run_hipmer_hpc\",\n    {\n        \"mer_size\": 51,\n        \"output_contigset_name\": \"chr14\",\n        \"min_depth_cutoff\": 4,\n        \"is_diploid\": 1,\n        \"dynamic_min_depth\": 1,\n        \"gap_close_rpt_depth_ratio\": 1.75,\n        \"reads\": [{\n            \"use_for_splinting\": 1,\n            \"use_for_gap_closing\": 1,\n            \"has_innie_artifact\": 0,\n            \"use_for_contigging\": 1,\n            \"ins_avg\": 155,\n            \"prefix\": \"FRAGS\",\n            \"ono_set_id\": 1,\n            \"tp_wiggle_room\": 0,\n            \"fp_wiggle_room\": 0,\n            \"read_library_name\": \"7998/24/1\",\n            \"is_rev_comped\": 0,\n            \"avg_read_len\": 101,\n            \"ins_dev\": 15\n        }, {\n            \"use_for_splinting\": 0,\n            \"use_for_gap_closing\": 1,\n            \"has_innie_artifact\": 0,\n            \"use_for_contigging\": 1,\n            \"ins_avg\": 2543,\n            \"prefix\": \"SJMP\",\n            \"ono_set_id\": 2,\n            \"tp_wiggle_room\": 0,\n            \"fp_wiggle_room\": 0,\n            \"read_library_name\": \"7998/22/1\",\n            \"is_rev_comped\": 1,\n            \"avg_read_len\": 101,\n            \"ins_dev\": 254\n        }, {\n            \"use_for_splinting\": 0,\n            \"use_for_gap_closing\": 0,\n            \"has_innie_artifact\": 0,\n            \"use_for_contigging\": 1,\n            \"ins_avg\": 35307,\n            \"prefix\": \"LJMP\",\n            \"ono_set_id\": 3,\n            \"tp_wiggle_room\": 25,\n            \"fp_wiggle_room\": 25,\n            \"read_library_name\": \"7998/20/1\",\n            \"is_rev_comped\": 0,\n            \"avg_read_len\": 0,\n            \"ins_dev\": 3531\n        }],\n        \"assm_scaff_len_cutoff\": 1000,\n        \"bubble_min_depth_cutoff\": 1\n    },\n    tag=\"dev\"\n)",
+					"cell_type": "code_cell"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "kbaseReportView",
+					"cell_type": "widget"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Load Chr14 data\nLet's load up Chromosome 14 from the human genome and assembly it with HipMer.  Thist data set is included as part of the HipMer distribution as a test case.\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Load Paired-End Reads From Staging Area",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "kbaseReadsViewer",
+					"cell_type": "widget"
+				}, {
+					"desc": "kbaseReadsViewer",
+					"cell_type": "widget"
+				}, {
+					"desc": "Load Paired-End Reads From Staging Area",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "kbaseReadsViewer",
+					"cell_type": "widget"
+				}, {
+					"desc": "Load Paired-End Reads From Staging Area",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "kbaseReadsViewer",
+					"cell_type": "widget"
+				}, {
+					"desc": "Old tests\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "kbaseReportView",
+					"cell_type": "widget"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "kbaseReportView",
+					"cell_type": "widget"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "kbaseReportView",
+					"cell_type": "widget"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Testing with Condor\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Assemble with HipMer",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Testing with new Job Runner\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "",
+					"cell_type": "code_cell"
+				}, {
+					"desc": "Assemble with HipMer - v1.0-829",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Testing with new Runner and v1.2.148 on KNL\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Assemble with HipMer - v1.2.1.48",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "V1.2.2\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Assemble with HipMer - v1.2.2-7",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Assemble with HipMer - v1.2.2-7",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Assemble with HipMer - v1.2.2-7",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Assemble with HipMer - v1.2.2-7",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Assemble Eukaryotic Reads with HipMer - v1.2.2-7",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Assemble Metagenomic Reads with HipMer - v1.2.2-7",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Upload File to Staging from Web - v1.0.12",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "Import FASTQ/SRA File as Reads from Staging Area",
+					"cell_type": "kbase_app"
+				}],
+				"total_cells": 49,
+				"static_narrative_saved": null,
+				"static_narrative_ref": null,
+				"shared_users": ["wjriehl", "eapearson", "kbasetest", "dolson", "scanon", "bobcottingham", "gaprice", "psdehal", "vkumar", "kbaseindexer", "fangfang", "chenry", "bsadkhin", "rsutormin", "msneddon", "dylan"],
+				"creation_date": "2016-06-15T17:36:08+0000",
+				"is_public": true,
+				"copied": null,
+				"tags": ["narrative"],
+				"obj_type_version": "4.0",
+				"obj_type_module": "KBaseNarrative"
+			},
+			"guid": "WS:7998/1/1",
+			"kbase_id": "7998/1/1",
+			"index_name": "narrative_2",
+			"type_ver": 0,
+			"highlight": {
+				"cells.desc": ["Loading E <em>Coli</em> Data"]
+			}
+		}, {
+			"object_name": "Narrative.1453140246703",
+			"access_group": 4132,
+			"obj_id": 1,
+			"version": 40,
+			"timestamp": 1456445146725,
+			"type": "Narrative",
+			"creator": "scanon",
+			"data": {
+				"narrative_title": "Annotation Test",
+				"is_temporary": false,
+				"is_narratorial": false,
+				"data_objects": [{
+					"name": "kb|g.1",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "kb|g.0",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "kb|g.100",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "Rhodobacter_CACIA_14H1_contigs",
+					"obj_type": "KBaseGenomes.ContigSet-2.0"
+				}, {
+					"name": "ASM704",
+					"obj_type": "KBaseGenomes.ContigSet-3.0"
+				}, {
+					"name": "rhodo.anno",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "Asm.anno",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "e",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "Ecoli",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "kb|g.0.rna.17",
+					"obj_type": "KBaseGenomes.Feature-2.1"
+				}, {
+					"name": "kb|g.0.rna.16",
+					"obj_type": "KBaseGenomes.Feature-2.1"
+				}, {
+					"name": "rhodo",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "Rsp-minimal",
+					"obj_type": "KBaseBiochem.Media-1.0"
+				}, {
+					"name": "mymodel.1",
+					"obj_type": "KBaseFBA.FBAModel-7.1"
+				}, {
+					"name": "ncbi-2937",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "asm704.contig",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "kb|g.3907",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "model.2",
+					"obj_type": "KBaseFBA.FBAModel-13.0"
+				}, {
+					"name": "model.2.gf.0",
+					"obj_type": "KBaseFBA.FBA-13.0"
+				}, {
+					"name": "kb|g.21.peg.753",
+					"obj_type": "KBaseGenomes.Feature-2.1"
+				}, {
+					"name": "kb|g.21.peg.759",
+					"obj_type": "KBaseGenomes.Feature-2.1"
+				}, {
+					"name": "kb|g.166828.locus.22187",
+					"obj_type": "KBaseGenomes.Feature-2.1"
+				}, {
+					"name": "kb|g.166828.locus.39324",
+					"obj_type": "KBaseGenomes.Feature-2.1"
+				}, {
+					"name": "GCF_000795365.1",
+					"obj_type": "KBaseGenomes.Genome-12.3"
+				}],
+				"owner": "scanon",
+				"modified_at": 1505231421000,
+				"cells": [{
+					"desc": "Let's Annotate the kb|g.0 Genome (E Coli)\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "\n\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "\n\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "\n\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "\n\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "\n\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "\n\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "\n\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "\n\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "\n\n",
+					"cell_type": "markdown"
+				}],
+				"total_cells": 10,
+				"static_narrative_saved": null,
+				"static_narrative_ref": null,
+				"shared_users": ["wjriehl", "eapearson", "rsutormin", "scanon", "msneddon"],
+				"creation_date": "2016-01-18T18:04:06+0000",
+				"is_public": false,
+				"copied": null,
+				"tags": [],
+				"obj_type_version": "4.0",
+				"obj_type_module": "KBaseNarrative"
+			},
+			"guid": "WS:4132/1/1",
+			"kbase_id": "4132/1/1",
+			"index_name": "narrative_2",
+			"type_ver": 0,
+			"highlight": {
+				"cells.desc": ["Let's Annotate the kb|g.0 Genome (E <em>Coli</em>)"]
+			}
+		}, {
+			"object_name": "Narrative.1439921920045",
+			"access_group": 1219,
+			"obj_id": 1,
+			"version": 344,
+			"timestamp": 1476217553327,
+			"type": "Narrative",
+			"creator": "nlharris",
+			"data": {
+				"narrative_title": "Metabolic Model Reconstruction and Analysis",
+				"is_temporary": false,
+				"is_narratorial": false,
+				"data_objects": [{
+					"name": "Shewanella_oneidensis_MR-1",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_draft_model",
+					"obj_type": "KBaseFBA.FBAModel-7.1"
+				}, {
+					"name": "iMR1_799_Shewanella_published_model",
+					"obj_type": "KBaseFBA.FBAModel-7.1"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_gapfilled_model.gffba",
+					"obj_type": "KBaseFBA.FBA-11.0"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_gapfilled_model",
+					"obj_type": "KBaseFBA.FBAModel-7.1"
+				}, {
+					"name": "C-D-Glucose",
+					"obj_type": "KBaseBiochem.Media-4.0"
+				}, {
+					"name": "C-D-Lactate",
+					"obj_type": "KBaseBiochem.Media-4.0"
+				}, {
+					"name": "C-acetate",
+					"obj_type": "KBaseBiochem.Media-4.0"
+				}, {
+					"name": "C-Butyrate",
+					"obj_type": "KBaseBiochem.Media-4.0"
+				}, {
+					"name": "C-Citrate",
+					"obj_type": "KBaseBiochem.Media-4.0"
+				}, {
+					"name": "BU12_10",
+					"obj_type": "KBaseBiochem.Media-4.0"
+				}, {
+					"name": "BU7_LacPrx",
+					"obj_type": "KBaseBiochem.Media-4.0"
+				}, {
+					"name": "fdx2_ActOxl_t2",
+					"obj_type": "KBaseBiochem.Media-4.0"
+				}, {
+					"name": "LB_4C_24h",
+					"obj_type": "KBaseBiochem.Media-4.0"
+				}, {
+					"name": "Shewanella_Phenotype_Set",
+					"obj_type": "KBasePhenotypes.PhenotypeSet-3.0"
+				}, {
+					"name": "Shewanella_SimPheno_Set",
+					"obj_type": "KBasePhenotypes.PhenotypeSimulationSet-3.0"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_LacPrx.gffba",
+					"obj_type": "KBaseFBA.FBA-11.0"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_LacPrx",
+					"obj_type": "KBaseFBA.FBAModel-7.1"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_GP1.gffba",
+					"obj_type": "KBaseFBA.FBA-11.0"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_GP1",
+					"obj_type": "KBaseFBA.FBAModel-7.1"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_GP2.gffba",
+					"obj_type": "KBaseFBA.FBA-11.0"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_GP2",
+					"obj_type": "KBaseFBA.FBAModel-7.1"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_GP3.gffba",
+					"obj_type": "KBaseFBA.FBA-11.0"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_GP3",
+					"obj_type": "KBaseFBA.FBAModel-7.1"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_GapfilledModel.gffba",
+					"obj_type": "KBaseFBA.FBA-11.0"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_GapfilledModel",
+					"obj_type": "KBaseFBA.FBAModel-7.1"
+				}, {
+					"name": "Shewanella_SimPheno_Set_Optimized",
+					"obj_type": "KBasePhenotypes.PhenotypeSimulationSet-3.0"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_FBA_Complete_media",
+					"obj_type": "KBaseFBA.FBA-11.0"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_GP3_Lactate",
+					"obj_type": "KBaseFBA.FBA-11.0"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_Gapfilled_Lactate.gffba",
+					"obj_type": "KBaseFBA.FBA-11.0"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_Gapfilled_Lactate",
+					"obj_type": "KBaseFBA.FBAModel-7.1"
+				}, {
+					"name": "Shewanella_oneidensis_MR-1_FBA_Lactate",
+					"obj_type": "KBaseFBA.FBA-11.0"
+				}, {
+					"name": "Acoerulea.JGI1.1",
+					"obj_type": "KBaseGenomes.Genome-8.0"
+				}, {
+					"name": "S.oneidensis-model",
+					"obj_type": "KBaseFBA.FBAModel-14.0"
+				}, {
+					"name": "S.oneidensis-model.gf.0",
+					"obj_type": "KBaseFBA.FBA-13.0"
+				}],
+				"owner": "janakakbase",
+				"modified_at": 1476217807000,
+				"cells": [{
+					"desc": "Microbial Metabolic Model Reconstruction and Analysis\nJanaka's version\n\nA key scientific objective of KBase\u2019s Microbes team is to reconstruct and predict metabolic and transcriptional regulatory networks to facilitate the manipulation of microbial function (for example, to optimize biofuel products). This tutorial highlights the tools in KBase that support the reconstruction and analysis of genome-scale metabolic models from genome sequence data.\n\nNOTE (to users): This tutorial is read-only. It shows the results of the steps. If you'd like to run the steps yourself--and maybe change some of the parameters or input your own data--you will need to make your own copy of it. Click the blue \u201cCopy Narrative\u201d button at the top right of the screen. This will copy the Narrative that you are currently viewing to your account, and you should see the new copy appear at the top of \u201cMy Narratives\u201d. The copy is now yours\u2013-you can open it, run it, edit it, and even share it with others. For more information, please see the Narrative User Guide.\n\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "The steps shown in this tutorial are:\n\n1. Load a Genome into your Narrative\nYou can upload your own data to KBase to analyze it, but for demonstration purposes in this tutorial, we\u2019ll start by choosing a data object\u2014-a genome\u2014-that's already in KBase and adding it to our Narrative.\nTo add the example genome, first click the Add Data (or red  \u201c+\u201d) button in the Data Panel on the left of your screen. (If you don\u2019t see this button, make sure you have the Analyze tab selected.)\n\nThe Data Browser will slide out, with tabs that show several data sources. Select the Public tab and search for Escherichia coli K12.\nFind the genome called \"EscherichiacoliK12\" and add it to your Narrative by hovering your cursor over it and clicking the Add button that appears at its left. (I will update this screenshot)\n\nExit the Data Browser by clicking either the Close button at the bottom right of the browser window or the arrow at the top of the Data Panel. (Note that you also can close the Data Browser by clicking anywhere in the main Narrative panel in the center.)\nAfter a moment your Data Panel will update to show the dataset that you just added.\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "2. What's in your Genome object?\nYou can click on the ShewanellaoneidensisMR-1 genome object in your Data panel to see a genome viewer (see below).\nIf you click on the name of the genome at the top of the viewer (ShewanellaoneidensisMR-1), a Landing Page (also called Detail Page) for that genome will open in a new browser tab.\n-- short explantion of each tab (from the genome man page/tutorial)\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Shewanella_oneidensis_MR-1",
+					"cell_type": "data"
+				}, {
+					"desc": "Build Metabolic Model",
+					"cell_type": "kbase_app"
+				}, {
+					"desc": "3. Reconstruction of Metabolic Model and Gapfill in Complete Media\nKBase\u2019s toolkit includes apps and methods for reconstruction, curation, reconciliation, and analysis of metabolic models. This section and the sections that follow explore some of that functionality.\nNow that you\u2019ve loaded a genome object into the narrative, you can build an initial draft metabolic model based on the gene annotations in your genome object.\nGo to the APPS & METHODS panel at the left. (If you don't see it, make sure you're looking at the \"Analyze\" tab.)\nIn KBase, apps and methods are the same thing except that an app consists of more than one method. You can search for apps or methods using the search box at the top of the Apps & Methods Panel (click the magnifying glass), or just scroll until you find the one you want. Find the \"Build Metabolic Model\" method and click on its name (or icon) to add it as a new step in your Narrative.\nNow you need to fill in the fields for the method. Choose the E. coli genome you loaded, and make up a name for the model that will be created. Then click the \"Run\" button at the bottom of the method cell to start building the model.\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Explantion of each tab in the gapfilled metabolic model \n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Below is the output of the Gapfilled Metabolic Model method. You can look at the different tabs, etc. Need an explantion for each tab (man pages/tutorials may already have the text)\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "\nReconstruct Genome-scale Metabolic Model (multi-step app)\n\n    Obsolete App!\n    \n    Sorry, this app is obsolete and can no longer function. But don't worry! Any data objects that were produced when you ran this app have been saved.\n    Please see the App Replacement page for more information.\n    Parameter settings you used:\n\nbuild_a_metabolic_modeltemplate_model - Noneinput_genome - Shewanella_oneidensis_MR-1core_model - 0output_model - Shewanella_oneidensis_MR-1_draft_modelfull_db_model - 0\ngapfill_a_metabolic_modelinput_model - Shewanella_oneidensis_MR-1_draft_modelcomprehensive_gapfill - 0output_model - Shewanella_oneidensis_MR-1_gapfilled_modelinput_media - Nonesource_model - iMR1_799_Shewanella_published_model\n\nSuggested replacement app(s):\n    The following replacement apps might help and are available in the Apps menu:build_a_metabolic_modelBuild Metabolic Modelgapfill_a_metabolic_modelGapfill Metabolic Model\n\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "",
+					"cell_type": "code_cell"
+				}, {
+					"desc": "",
+					"cell_type": "code_cell"
+				}, {
+					"desc": "\nRun Flux Balance Analysis\n\n    Obsolete App!\n    \n    Sorry, this app is obsolete and can no longer function. But don't worry! Any data objects that were produced when you ran this app have been saved.\n    Please see the App Replacement page for more information.\n    Parameter settings you used:\n\nMax Phosphate Uptake - None\nObjective constraint - 0.1\nOutput FBA Result - Shewanella_oneidensis_MR-1_gapfilled_model.gffba\nExpression threshold - 0.5\nMax Carbon Uptake - None\nExpression uncertainty - 0.1\nMedia - None\nMax Sulfur Uptake - None\nFlux Variability Analysis? - 1\nReaction Knockouts - None\nReaction to maximize - bio1\nFBA Model - Shewanella_oneidensis_MR-1_gapfilled_model\nExpression condition - None\nDiscrete formulation - 1\nSimulate All Single KO? - 0\nUniversal genes-based threshold - 1\nAdditional Compounds - None\nExpression matrix - None\nGene Knockouts - None\nCustom flux bounds - None\nMax Nitrogen Uptake - None\nMinimize Flux? - 1\n\nSuggested replacement app(s):\n    The following replacement apps might help and are available in the Apps menu:Run Flux Balance Analysis\n\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "4. Run Flux Balance Analysis on Complete media\nOnce you have built a metabolic model, you can perform flux balance analysis (FBA) to calculate the flow of metabolites through your model. FBA results can be used to predict the growth rate of an organism under certain conditions or the production rates for particular metabolites of interest.\nIn order to perform FBA, you need to describe the media conditions that you want to investigate using your metabolic model. There are about 500 media conditions currently users have acces via the data pane under public tab. (Explantion of chosing media by flitering \"Media\" in the dropdown and adding\na media forumuation into the narrative.  \n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "",
+					"cell_type": "code_cell"
+				}, {
+					"desc": "Here we import a Phenotype Set...\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "",
+					"cell_type": "code_cell"
+				}, {
+					"desc": "\nSimulate Growth on Phenotype Data\n\n    Obsolete App!\n    \n    Sorry, this app is obsolete and can no longer function. But don't worry! Any data objects that were produced when you ran this app have been saved.\n    Please see the App Replacement page for more information.\n    Parameter settings you used:\n\nPhenotype Simulation Result - Shewanella_Simpheno_Set\nFBA Model - Shewanella_oneidensis_MR-1_gapfilled_model\nPhenotype Set - Shewanella_Phenotype_Set\n\nSuggested replacement app(s):\n    The following replacement apps might help and are available in the Apps menu:Simulate Growth on Phenotype Data\n\n",
+					"cell_type": "markdown"
+				}, {
+					"desc": "Acoerulea.JGI1.1",
+					"cell_type": "data"
+				}],
+				"total_cells": 20,
+				"static_narrative_saved": null,
+				"static_narrative_ref": null,
+				"shared_users": ["eapearson", "betty", "bobcottingham", "mills", "ildubchak", "nlharris", "hlh35", "chenry", "janakakbase", "seaver", "drakemm2", "bpb", "aparkin", "dejongh", "msneddon", "ballen9"],
+				"creation_date": "2015-08-18T18:18:41+0000",
+				"is_public": false,
+				"copied": null,
+				"tags": [],
+				"obj_type_version": "4.0",
+				"obj_type_module": "KBaseNarrative"
+			},
+			"guid": "WS:1219/1/1",
+			"kbase_id": "1219/1/1",
+			"index_name": "narrative_2",
+			"type_ver": 0,
+			"highlight": {
+				"cells.desc": ["Select the Public tab and search for Escherichia <em>coli</em> K12.", "Choose the E. <em>coli</em> genome you loaded, and make up a name for the model that will be created."]
+			}
+		}],
+		"access_group_narrative_info": {
+			"54113": ["Fungi", 1, 1601339675000, "eapearson", "Erik A Pearson"],
+			"1219": ["Metabolic Model Reconstruction and Analysis", 1, 1476217807000, "janakakbase", "Janaka N Edirisinghe"],
+			"4132": ["Annotation Test", 1, 1505231421000, "scanon", "Shane Canon"],
+			"33192": ["Test fiesta", 1, 1599598844000, "jayrbolton", "Jay Bolton"],
+			"52489": ["Taxonomy Landing Page Testing", 1, 1609804811000, "eapearson", "Erik A Pearson"],
+			"9004": ["External_source_reference_genomes_for_testing", 64, 1469599902000, "marcin", "marcin joachimiak"],
+			"48753": ["RE landing page sample links", 1, 1586539906000, "eapearson", "Erik A Pearson"],
+			"44150": ["Relation Engine (RE) Landing Page Demo", 1, 1582215852000, "eapearson", "Erik A Pearson"],
+			"7998": ["HipMer Testing", 1, 1600899853000, "scanon", "Shane Canon"]
+		}
+	}]
+}

--- a/tests/integration/test_legacy_search_objects.py
+++ b/tests/integration/test_legacy_search_objects.py
@@ -35,3 +35,77 @@ def test_search_objects_many_results(service):
     [result] = assert_jsonrpc20_result(data, response_data)
 
     assert result['total'] > 10000
+
+
+def assert_counts(service, with_private, with_public, expected_count):
+    url = service['app_url'] + '/legacy'
+
+    if 'WS_TOKEN' not in os.environ:
+        pytest.skip('Token required for this test')
+
+    request_data = load_data_file('case-03-request.json')
+    request_data['params'][0]['access_filter']['with_private'] = with_private
+    request_data['params'][0]['access_filter']['with_public'] = with_public
+
+    response_data = load_data_file('case-03-response.json')
+
+    resp = requests.post(
+        url=url,
+        headers={'Authorization': os.environ['WS_TOKEN']},
+        data=json.dumps(request_data),
+    )
+    data = resp.json()
+    #  TODO: should be version 1.1 (aka jsonrpc 1.1)
+    [result] = assert_jsonrpc20_result(data, response_data)
+
+    assert result['total'] == expected_count
+
+
+def get_count(service, with_private, with_public):
+    url = service['app_url'] + '/legacy'
+
+    if 'WS_TOKEN' not in os.environ:
+        pytest.skip('Token required for this test')
+
+    request_data = load_data_file('case-03-request.json')
+    request_data['params'][0]['access_filter']['with_private'] = with_private
+    request_data['params'][0]['access_filter']['with_public'] = with_public
+
+    response_data = load_data_file('case-03-response.json')
+
+    resp = requests.post(
+        url=url,
+        headers={'Authorization': os.environ['WS_TOKEN']},
+        data=json.dumps(request_data),
+    )
+    data = resp.json()
+    #  TODO: should be version 1.1 (aka jsonrpc 1.1)
+    [result] = assert_jsonrpc20_result(data, response_data)
+
+    return result['total']
+
+#
+# This series of tests relies upon a specific state of data in
+# search.
+
+
+def test_search_objects_private_and_public(service):
+    assert_counts(service, 1, 1, 8)
+
+
+def test_search_objects_private(service):
+    assert_counts(service, 1, 0, 2)
+
+
+def test_search_objects_public(service):
+    assert_counts(service, 0, 1, 6)
+
+# A safer but less precise method.
+
+
+def test_search_objects_public_vs_private(service):
+    all_count = get_count(service, 1, 1)
+    private_count = get_count(service, 1, 0)
+    public_count = get_count(service, 0, 1)
+    assert private_count < all_count
+    assert public_count < all_count

--- a/tests/unit/es_client/test_es_client.py
+++ b/tests/unit/es_client/test_es_client.py
@@ -126,6 +126,19 @@ def test_search_unknown_index(services):
         assert str(ctx.value) == f"no such index [{full_name}]"
 
 
+def test_search_bad_query(services):
+    with patch('src.es_client.query.ws_auth') as mocked:
+        mocked.return_value = [0, 1]  # Public workspaces
+        # force a bad query by passing a nonsensical sort value.
+        params = {
+            'indexes': ['index1'],
+            'sort': 'x'
+        }
+        with pytest.raises(ElasticsearchError) as ctx:
+            search(params, {'auth': None})
+        assert str(ctx.value) == "all shards failed"
+
+
 def test_search_private_valid(services):
     with patch('src.es_client.query.ws_auth') as mocked:
         mocked.return_value = [100]  # Private workspaces this fictional user has access to

--- a/tests/unit/search1_conversion/test_search1_convert_params.py
+++ b/tests/unit/search1_conversion/test_search1_convert_params.py
@@ -12,7 +12,7 @@ def test_search_objects_valid():
         'query': {'bool': {}},
         'size': 20, 'from': 0,
         'sort': [{'timestamp': {'order': 'asc'}}],
-        'public_only': False, 'private_only': False,
+        'only_public': False, 'only_private': False,
         'track_total_hits': True
     }
     query = convert_params.search_objects(params)
@@ -34,7 +34,7 @@ def test_search_objects_highlight():
         },
         'size': 20, 'from': 0,
         'sort': [{'timestamp': {'order': 'asc'}}],
-        'public_only': False, 'private_only': False,
+        'only_public': False, 'only_private': False,
         'track_total_hits': True
     }
     query = convert_params.search_objects(params)
@@ -49,7 +49,8 @@ def test_search_objects_fulltext():
         'query': {'bool': {'must': [{'match': {'agg_fields': 'xyz'}}]}},
         'size': 20, 'from': 0,
         'sort': [{'timestamp': {'order': 'asc'}}],
-        'public_only': False, 'private_only': False,
+        'only_public': False,
+        'only_private': False,
         'track_total_hits': True
     }
     query = convert_params.search_objects(params)
@@ -64,7 +65,7 @@ def test_search_objects_object_name():
         'query': {'bool': {'must': [{'match': {'obj_name': 'xyz'}}]}},
         'size': 20, 'from': 0,
         'sort': [{'timestamp': {'order': 'asc'}}],
-        'public_only': False, 'private_only': False,
+        'only_public': False, 'only_private': False,
         'track_total_hits': True
     }
     query = convert_params.search_objects(params)
@@ -79,7 +80,7 @@ def test_search_objects_timestamp():
         'query': {'bool': {'must': [{'range': {'timestamp': {'gte': 0, 'lte': 1}}}]}},
         'size': 20, 'from': 0,
         'sort': [{'timestamp': {'order': 'asc'}}],
-        'public_only': False, 'private_only': False,
+        'only_public': False, 'only_private': False,
         'track_total_hits': True
     }
     query = convert_params.search_objects(params)
@@ -102,7 +103,7 @@ def test_search_objects_source_tags():
         'query': {'bool': {'must': [{'term': {'tags': 'x'}}, {'term': {'tags': 'y'}}]}},
         'size': 20, 'from': 0,
         'sort': [{'timestamp': {'order': 'asc'}}],
-        'public_only': False, 'private_only': False,
+        'only_public': False, 'only_private': False,
         'track_total_hits': True
     }
     query = convert_params.search_objects(params)
@@ -117,7 +118,7 @@ def test_search_objects_source_tags_blacklist():
         'query': {'bool': {'must_not': [{'term': {'tags': 'x'}}, {'term': {'tags': 'y'}}]}},
         'size': 20, 'from': 0,
         'sort': [{'timestamp': {'order': 'asc'}}],
-        'public_only': False, 'private_only': False,
+        'only_public': False, 'only_private': False,
         'track_total_hits': True
     }
     query = convert_params.search_objects(params)
@@ -140,7 +141,7 @@ def test_search_objects_objtypes():
         'indexes': ['genome_features_2'],
         'size': 20, 'from': 0,
         'sort': [{'timestamp': {'order': 'asc'}}],
-        'public_only': False, 'private_only': False,
+        'only_public': False, 'only_private': False,
         'track_total_hits': True
     }
     query = convert_params.search_objects(params)
@@ -158,7 +159,7 @@ def test_search_objects_sorting():
         'query': {'bool': {}},
         'sort': [{'x': {'order': 'asc'}}, {'timestamp': {'order': 'desc'}}],
         'size': 20, 'from': 0,
-        'public_only': False, 'private_only': False,
+        'only_public': False, 'only_private': False,
         'track_total_hits': True
     }
     query = convert_params.search_objects(params)
@@ -195,7 +196,7 @@ def test_search_objects_lookup_in_keys():
         },
         'size': 20, 'from': 0,
         'sort': [{'timestamp': {'order': 'asc'}}],
-        'public_only': False, 'private_only': False,
+        'only_public': False, 'only_private': False,
         'track_total_hits': True
     }
     query = convert_params.search_objects(params)
@@ -211,7 +212,8 @@ def test_search_types_valid():
         'size': 0, 'from': 0,
         'aggs': {'type_count': {'terms': {'field': 'obj_type_name'}}},
         'sort': [{'timestamp': {'order': 'asc'}}],
-        'public_only': False, 'private_only': False,
+        'only_public': False,
+        'only_private': False,
         'track_total_hits': True
     }
     query = convert_params.search_types(params)

--- a/tests/unit/search1_conversion/test_search1_convert_params.py
+++ b/tests/unit/search1_conversion/test_search1_convert_params.py
@@ -229,3 +229,72 @@ def test_get_objects_valid():
     }
     query = convert_params.get_objects(params)
     assert query == expected
+
+
+def test_search_objects_only_public():
+    params = {
+        'match_filter': {},
+        'access_filter': {
+            'with_public': 1
+        }
+    }
+    expected = {
+        'query': {'bool': {}},
+        'size': 20, 'from': 0,
+        'sort': [{'timestamp': {'order': 'asc'}}],
+        'only_public': True, 'only_private': False,
+        'track_total_hits': True
+    }
+    query = convert_params.search_objects(params)
+    assert query == expected
+
+
+def test_search_objects_only_private():
+    params = {
+        'match_filter': {},
+        'access_filter': {
+            'with_private': 1
+        }
+    }
+    expected = {
+        'query': {'bool': {}},
+        'size': 20, 'from': 0,
+        'sort': [{'timestamp': {'order': 'asc'}}],
+        'only_public': False, 'only_private': True,
+        'track_total_hits': True
+    }
+    query = convert_params.search_objects(params)
+    assert query == expected
+
+
+def test_search_objects_private_and_public():
+    params = {
+        'match_filter': {},
+        'access_filter': {
+            'with_private': 1,
+            'with_public': 1
+        }
+    }
+    expected = {
+        'query': {'bool': {}},
+        'size': 20, 'from': 0,
+        'sort': [{'timestamp': {'order': 'asc'}}],
+        'only_public': False, 'only_private': False,
+        'track_total_hits': True
+    }
+    query = convert_params.search_objects(params)
+    assert query == expected
+
+
+def test_search_objects_private_nor_public():
+    params = {
+        'match_filter': {},
+        'access_filter': {
+            'with_private': 0,
+            'with_public': 0
+        }
+    }
+    with pytest.raises(ResponseError) as re:
+        convert_params.search_objects(params)
+    assert re.value.jsonrpc_code == -32602
+    assert re.value.message == 'May not specify no private data and no public data'

--- a/tests/unit/utils/test_workspace.py
+++ b/tests/unit/utils/test_workspace.py
@@ -1,9 +1,38 @@
 import pytest
 import responses
+import json
 
 from src.utils.config import config
 from src.utils.workspace import ws_auth, get_workspace_info
 from src.exceptions import ResponseError
+
+# TODO: All tests should be rewritten to use an explicit service call matcher
+# where applicable. This ensures that the precisely correct call has been made.
+
+
+def service_call_matcher(method, params):
+    def match(request_body):
+        try:
+            if isinstance(request_body, bytes):
+                request_body = request_body.decode("utf-8")
+
+            if request_body is None:
+                return False
+
+            rpc = json.loads(request_body)
+
+            if rpc['method'] != method:
+                return False
+
+            if rpc['params'] != [params]:
+                return False
+
+            return True
+        except json.JSONDecodeError:
+            return False
+
+    return match
+
 
 mock_ws_ids_with_auth = {
     "version": "1.1",
@@ -11,6 +40,27 @@ mock_ws_ids_with_auth = {
         {
             "workspaces": [1, 2, 3],
             "pub": [10, 11]
+        }
+    ]
+}
+
+mock_ws_ids_with_auth_only_public = {
+    "version": "1.1",
+    "result": [
+        {
+            "workspaces": [],
+            "pub": [10, 11]
+        }
+    ]
+}
+
+
+mock_ws_ids_with_auth_only_private = {
+    "version": "1.1",
+    "result": [
+        {
+            "workspaces": [1, 2, 3],
+            "pub": []
         }
     ]
 }
@@ -93,10 +143,70 @@ def test_ws_auth_valid():
     responses.add(responses.POST,
                   config['workspace_url'],
                   headers={'Authorization': 'valid_token'},
+                  match=[
+                      service_call_matcher(
+                          'Workspace.list_workspace_ids',
+                          {
+                              'perm': 'r',
+                              'onlyGlobal': 0,
+                              'excludeGlobal': 0
+                          }
+                      )
+                  ],
                   json=mock_ws_ids_with_auth,
                   status=200)
     result = ws_auth('valid_token')
     assert result == [1, 2, 3, 10, 11]
+
+
+@responses.activate
+def test_ws_auth_valid_public():
+    responses.add(responses.POST,
+                  config['workspace_url'],
+                  headers={'Authorization': 'valid_token'},
+                  match=[
+                      service_call_matcher(
+                          'Workspace.list_workspace_ids',
+                          {
+                              'perm': 'r',
+                              'onlyGlobal': 1,
+                              'excludeGlobal': 0
+                          }
+                      )
+                  ],
+                  json=mock_ws_ids_with_auth_only_public,
+                  status=200)
+    result = ws_auth('valid_token', only_public=True)
+    assert result == [10, 11]
+
+
+@responses.activate
+def test_ws_auth_valid_private():
+    # Mock the workspace call
+    responses.add(responses.POST,
+                  config['workspace_url'],
+                  headers={'Authorization': 'valid_token'},
+                  match=[
+                      service_call_matcher(
+                          'Workspace.list_workspace_ids',
+                          {
+                              'perm': 'r',
+                              'onlyGlobal': 0,
+                              'excludeGlobal': 1
+                          }
+                      )
+                  ],
+                  json=mock_ws_ids_with_auth_only_private,
+                  status=200)
+    result = ws_auth('valid_token', only_private=True)
+    assert result == [1, 2, 3]
+
+
+def test_ws_auth_error_private_and_public():
+    # Mock the workspace call
+    with pytest.raises(Exception) as ex:
+        ws_auth('valid_token', only_private=True, only_public=True)
+    assert 'Only one of "only_public" or "only_private" may be set' in str(ex)
 
 
 @responses.activate
@@ -112,7 +222,7 @@ def test_ws_auth_blank():
 
 @responses.activate
 def test_ws_auth_invalid():
-    # Mock the workspace call
+    # Mock the workspace daily
     responses.add(responses.POST,
                   config['workspace_url'],
                   headers={'Authorization': 'invalid_token'},


### PR DESCRIPTION
The problem being fixed is described in SCT-2930 as a failure to honor the withPublic and withPrivate parameters for the legacy api's get_objects method.

The gist of this problem is that the internal api uses "only_public" and "only_private" keys, but this call had set the keys to "public_only" and "private_only". Since the wrong keys were used, the code always considered the options to be absent, and always created a search query that includes public and private objects.

The solution lies in fixing these keys.

While preparing the tests, the internal logic for handling only_public and only_private was also refactored to raise an error in case they are both set to true, and also the parameter validation for with_public and with_private rpc params was made stricter to prevent this on the rpc side. Tests were added to handle this case as well.

This did reveal a problem in error generation and handling for parameter errors which fall outside of the scope of jsonschema. I'll file a bug report for this with details.

Other unit tests were added to bring unit test coverage back to 100%