### PR TITLE
fix object_types having no effect on search_objects

### DIFF
--- a/tests/unit/search1_conversion/test_search1_convert_params.py
+++ b/tests/unit/search1_conversion/test_search1_convert_params.py
@@ -134,10 +134,14 @@ def test_search_objects_objtypes():
     expected = {
         'query': {
             'bool': {
-                'should': [
-                    {'term': {'obj_type_name': 'x'}},
-                    {'term': {'obj_type_name': 'y'}}
-                ]
+                'filter': {
+                    'bool': {
+                        'should': [
+                            {'term': {'obj_type_name': 'x'}},
+                            {'term': {'obj_type_name': 'y'}}
+                        ]
+                    }
+                }
             }
         },
         'indexes': ['genome_features_2'],


### PR DESCRIPTION
Fixes SCT-2969: search_api2 legacy search_objects does not honor “object_types” option

This was a fairly simple fix. The `object_types` parameter was working for search_types but not search_objects. This had to do with the query construction. The object types filter, being an "or" constraint, should have been applied in a filter context; otherwise the "should" filter does not act as an "or" filter but rather for scoring.

Also refactored the query building a little to remove some repeated boilerplate.

Updated object_types test to work with the fixed query