### PR TITLE
Fixes SCT-2970: Legacy search_objects should narrow with additional search terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- fix SCT-2947: unauthenticated search not working correctly (no ws or narr info)
-- fix SCT-2932: throws error if object has been deleted
+- fix SCT-2930: not honoring withPublic and withPrivate
 - fix SCT-2931: maximum reported search results was 10,000 - fixed to report actual search results with > 10K.
-- fix SCT-2930: was not honoring withPublic and withPrivate
+- fix SCT-2932: throws error if object has been deleted
+- fix SCT-2933, SCT-2956: Searchapi2 legacy endpoint uses jsonrpc 2.0 not 1.1
+- fix SCT-2937: searchapi2/legacy search_objects should be tolerant of inaccessible workspaces
+- fix SCT-2947: unauthenticated search not working correctly (no ws or narr info)
+- fix SCT-2969: not honoring object_types
+- fix SCT-2970: not narrowing search with additional terms
 
 ### Changed
 - implement SCT-2966: add a "build and test" workflow for GitHub Actions which builds an image, runs tests, and pushes the resulting image too GH Container Registry.

--- a/docs/ez-guide.md
+++ b/docs/ez-guide.md
@@ -128,5 +128,5 @@ tests/integration/test_integration_search_workspaces.py::test_dashboard_example 
 ## Using with kbase-ui
 
 ```
-IP="<IP HERE>" SSHHOST="login1.berkeley.kbase.us" SSHUSER="<KBASE DEV USERNAME>" SSHPASS="<KBASE DEV PWD>" docker-compose --file tests/integration/docker-compose.yaml up
+IP="<IP HERE>" SSHHOST="login1.berkeley.kbase.us" SSHUSER="<KBASE DEV USERNAME>" SSHPASS="<KBASE DEV PWD>" make run-dev-server
 ```

--- a/src/search1_conversion/convert_params.py
+++ b/src/search1_conversion/convert_params.py
@@ -149,11 +149,23 @@ def _get_search_params(params):
     # Provides for full text search
     if match_filter.get('full_text_in_all'):
         # Match full text for any field in the objects
-        query['bool']['must'].append({'match': {'agg_fields': match_filter['full_text_in_all']}})
+        terms = match_filter.get('full_text_in_all')
+        query['bool']['must'].append({
+            'match': {
+                'agg_fields': {
+                    'query': terms,
+                    'operator': 'AND'
+                }
+            }
+        })
 
     # Search by object name, precisely, so more of a filter.
     if match_filter.get('object_name'):
-        query['bool']['must'].append({'match': {'obj_name': str(match_filter['object_name'])}})
+        query['bool']['must'].append({
+            'match': {
+                'obj_name': str(match_filter['object_name'])
+            }
+        })
 
     # Search by timestamp range
     if match_filter.get('timestamp') is not None:
@@ -161,7 +173,11 @@ def _get_search_params(params):
         min_ts = ts.get('min_date')
         max_ts = ts.get('max_date')
         if min_ts is not None and max_ts is not None and min_ts < max_ts:
-            query['bool']['must'].append({'range': {'timestamp': {'gte': min_ts, 'lte': max_ts}}})
+            query['bool']['must'].append({
+                'range': {
+                    'timestamp': {'gte': min_ts, 'lte': max_ts}
+                }
+            })
         else:
             raise InvalidParamsError(message="Invalid timestamp range in match_filter/timestamp")
 

--- a/tests/helpers/common.py
+++ b/tests/helpers/common.py
@@ -48,7 +48,8 @@ def assert_jsonrpc11_result(actual, expected):
     result = actual['result']
     assert isinstance(result,  list)
     assert 'error' not in actual
-    return result
+    assert len(result) == 1
+    return result[0]
 
 
 def assert_jsonrpc11_error(actual, expected):

--- a/tests/integration/legacy_data.py
+++ b/tests/integration/legacy_data.py
@@ -355,3 +355,49 @@ search_request6 = {
     "version": "1.1",
     "id": "4564119057768642"
 }
+
+# Make sure adding additional terms results in narrowing the search.
+# A request to get a total count on refdata for a search query
+
+# Test multiple terms
+search_request_7 = {
+    'rpc': {
+        "id": "xyz",
+        "method": "KBaseSearchEngine.search_objects",
+        "version": "1.1",
+        "params": [{
+            "access_filter": {
+                "with_private": 0,
+                "with_public": 1
+            },
+            "match_filter": {
+                "exclude_subobjects": 1,
+                "full_text_in_all": "coli",
+                "source_tags": ["refdata"],
+                "source_tags_blacklist": 0
+            },
+            "pagination": {
+                "count": 0,
+                "start": 0
+            },
+            "post_processing": {
+                "ids_only": 1,
+                "include_highlight": 1,
+                "skip_data": 1,
+                "skip_info": 1,
+                "skip_keys": 1
+            }
+        }]
+    },
+    'cases': [{
+        'full_text_in_all': 'Prochlorococcus marinus',
+        'total': 11
+    },  {
+        'full_text_in_all': 'Prochlorococcus',
+        'total': 18
+    }, {
+        'full_text_in_all': 'marinus',
+        'total': 12
+    }]
+}
+

--- a/tests/integration/legacy_data.py
+++ b/tests/integration/legacy_data.py
@@ -400,4 +400,3 @@ search_request_7 = {
         'total': 12
     }]
 }
-

--- a/tests/integration/test_integration_legacy.py
+++ b/tests/integration/test_integration_legacy.py
@@ -149,7 +149,7 @@ def test_search_example_7(service):
 
     rpc = search_request_7['rpc']
 
-    for case in  search_request_7['cases']:
+    for case in search_request_7['cases']:
         rpc['params'][0]['match_filter']['full_text_in_all'] = case['full_text_in_all']
         resp = requests.post(
             url=url,

--- a/tests/integration/test_integration_legacy.py
+++ b/tests/integration/test_integration_legacy.py
@@ -15,6 +15,7 @@ from tests.integration.legacy_data import (
     search_request5,
     search_response5,
     search_request6,
+    search_request_7
 )
 from tests.helpers.common import (
     assert_jsonrpc11_result,
@@ -111,12 +112,8 @@ def test_search_example5(service):
         url=url,
         data=json.dumps(search_request5),
     )
-    data = resp.json()
-    assert data['version'] == search_response5['version']
-    assert data['id'] == search_response5['id']
-    assert len(data['result']) == 1
+    res = assert_jsonrpc11_result(resp.json(), search_request5)
     expected_res = search_response5['result'][0]
-    res = data['result'][0]
     assert set(res.keys()) == set(expected_res.keys())
     assert res['pagination'] == expected_res['pagination']
     assert res['sorting_rules'] == expected_res['sorting_rules']
@@ -137,21 +134,33 @@ def test_search_example6(service):
         headers={'Authorization': os.environ['WS_TOKEN']},
         data=json.dumps(search_request6),
     )
-    data = resp.json()
-    assert data['version'] == '1.1'
-    assert data['id'] == search_request6['id']
-    assert len(data['result']) == 1
-    res = data['result'][0]
+    res = assert_jsonrpc11_result(resp.json(), search_request6)
     assert len(res['objects']) > 0
     for obj in res['objects']:
         assert len(obj['highlight']) > 0
 
-#
+
+def test_search_example_7(service):
+    """Test multiple terms"""
+    url = service['app_url'] + '/legacy'
+
+    if 'WS_TOKEN' not in os.environ:
+        pytest.skip('Token required for this test')
+
+    rpc = search_request_7['rpc']
+
+    for case in  search_request_7['cases']:
+        rpc['params'][0]['match_filter']['full_text_in_all'] = case['full_text_in_all']
+        resp = requests.post(
+            url=url,
+            headers={'Authorization': os.environ['WS_TOKEN']},
+            data=json.dumps(rpc),
+        )
+        res = assert_jsonrpc11_result(resp.json(), rpc)
+        assert res['total'] == case['total']
 
 # This is a normal data-search usage, which returns the
 # workspace info and narrative info, for public data.
-
-
 # Simulates search from data-search with a search term, only public data
 
 

--- a/tests/integration/test_legacy_search_objects.py
+++ b/tests/integration/test_legacy_search_objects.py
@@ -31,17 +31,14 @@ def test_search_objects_many_results(service):
         headers={'Authorization': os.environ['WS_TOKEN']},
         data=json.dumps(request_data),
     )
-    data = resp.json()
-    [result] = assert_jsonrpc11_result(data, response_data)
-
+    result = assert_jsonrpc11_result(resp.json(), response_data)
     assert result['total'] > 10000
 
 
 def assert_counts(service, with_private, with_public, expected_count):
     resp = make_call(service, with_private, with_public)
     response_data = load_data_file('case-03-response.json')
-    data = resp.json()
-    [result] = assert_jsonrpc11_result(data, response_data)
+    result = assert_jsonrpc11_result(resp.json(), response_data)
     assert result['total'] == expected_count
 
 
@@ -71,12 +68,8 @@ def get_error(service, with_private, with_public):
 
 def get_count(service, with_private, with_public):
     resp = make_call(service, with_private, with_public)
-
     response_data = load_data_file('case-03-response.json')
-
-    data = resp.json()
-    [result] = assert_jsonrpc11_result(data, response_data)
-
+    result = assert_jsonrpc11_result(resp.json(), response_data)
     return result['total']
 
 #

--- a/tests/unit/search1_conversion/test_search1_convert_params.py
+++ b/tests/unit/search1_conversion/test_search1_convert_params.py
@@ -27,11 +27,32 @@ def test_search_objects_highlight():
         }
     }
     expected = {
-        'query': {'bool': {'must': [{'match': {'agg_fields': 'x'}}]}},
+        'query': {
+            'bool': {
+                'must': [{
+                    'match': {
+                        'agg_fields': {
+                            'query': 'x',
+                            'operator': 'AND'
+                        }
+                    }
+                }]
+            }
+        },
         'highlight': {
             'fields': {'*': {}},
-            'highlight_query': {'bool': {'must': [{'match': {'agg_fields': {'operator': 'AND',
-                                                                            'query': 'x'}}}]}},
+            'highlight_query': {
+                'bool': {
+                    'must': [{
+                        'match': {
+                            'agg_fields': {
+                                'query': 'x',
+                                'operator': 'AND'
+                            }
+                        }
+                    }]
+                }
+            },
             'require_field_match': False,
         },
         'size': 20, 'from': 0,
@@ -48,7 +69,18 @@ def test_search_objects_fulltext():
         'match_filter': {'full_text_in_all': 'xyz'},
     }
     expected = {
-        'query': {'bool': {'must': [{'match': {'agg_fields': 'xyz'}}]}},
+        'query': {
+            'bool': {
+                'must': [{
+                    'match': {
+                        'agg_fields': {
+                            'query': 'xyz',
+                            'operator': 'AND'
+                        }
+                    }
+                }]
+            }
+        },
         'size': 20, 'from': 0,
         'sort': [{'timestamp': {'order': 'asc'}}],
         'only_public': False,


### PR DESCRIPTION
The `full_text_in_all` match filter should narrow search results when more than one term (a word separated by whitespace) is utilized, but at present it actually expands the search. This is because elasticsearch normally uses result scoring to provide search relevancy. In our case we need precise searches since we order by workspace id, not score. 

This PR includes the fix for this, as well as new and adjusted tests.